### PR TITLE
Add hint attribute to elements

### DIFF
--- a/input/tangy-checkboxes.js
+++ b/input/tangy-checkboxes.js
@@ -47,6 +47,7 @@ class TangyCheckboxes extends PolymerElement {
       </style>
       <div class="container">
         <label for="group">[[label]]</label>
+        <label class="hint-text">[[hintText]]</label>
         <span class="secondary_color">[[t.selectOneOrMore]]</span>
         <div id="checkboxes">
         </div>
@@ -66,6 +67,11 @@ class TangyCheckboxes extends PolymerElement {
         type: Array,
         value: [],
         observer: 'reflect',
+        reflectToAttribute: true
+      },
+      hintText: {
+        type: String,
+        value: '',
         reflectToAttribute: true
       },
       atLeast: {

--- a/input/tangy-eftouch.js
+++ b/input/tangy-eftouch.js
@@ -31,6 +31,11 @@ export class TangyEftouch extends PolymerElement {
         reflectToAttribute: true,
         observer: 'render'
       },
+      hintText: {
+        type: String,
+        value: '',
+        reflectToAttribute: true
+      },
       width: {
         type: Number,
         reflectToAttribute: true,

--- a/input/tangy-gps.js
+++ b/input/tangy-gps.js
@@ -85,10 +85,12 @@ class TangyGps extends PolymerElement {
       .coordinates {
         margin: 5px 15px;
       }
+      .hint-text{
+        margin-top:6px;
+      }
     </style>
 
     <div class="coordinates">
-
       <div id="lat-long">
         <span class="label">[[t.latitude]]:</span> [[currentLatitude]] <br>
         <span class="label">[[t.longitude]]:</span> [[currentLongitude]] <br>
@@ -107,7 +109,7 @@ class TangyGps extends PolymerElement {
         <br> 
         <span class="label">[[t.disanceFromReference]]:</span> [[currentDelta]] meters
       </template>
-
+      <label class="hint-text">[[hintText]]</label>
     </div>
 
     <div>
@@ -136,6 +138,11 @@ class TangyGps extends PolymerElement {
           accuracy: undefined
         },
         observer: 'reflect',
+        reflectToAttribute: true
+      },
+      hintText: {
+        type: String,
+        value: '',
         reflectToAttribute: true
       },
       required: {

--- a/input/tangy-input.js
+++ b/input/tangy-input.js
@@ -71,6 +71,7 @@ export class TangyInput extends PolymerElement {
           <div slot="suffix"></div>
         </template>
       </paper-input>
+      <label class="hint-text">[[hintText]]</label>
     </div>
   `
   }
@@ -88,6 +89,10 @@ export class TangyInput extends PolymerElement {
         value: false
       },
       label: {
+        type: String,
+        value: ''
+      },
+      hintText: {
         type: String,
         value: ''
       },

--- a/input/tangy-location.js
+++ b/input/tangy-location.js
@@ -443,6 +443,7 @@ class TangyLocation extends PolymerElement {
   /* End of Materialize Select Styles */
       </style>
       <div id="container"></div>
+      <label class="hint-text">[[hintText]]</label>
 `;
   }
 
@@ -451,6 +452,10 @@ class TangyLocation extends PolymerElement {
       name: {
         type: String,
         value: 'location'
+      },
+      hintText: {
+        type: String,
+        value: ''
       },
       value: {
         type: Array,

--- a/input/tangy-photo-capture.js
+++ b/input/tangy-photo-capture.js
@@ -22,20 +22,28 @@ export class TangyPhotoCapture extends PolymerElement {
       img {
         width: 100%;
       }
+      .hint-text{
+        margin-top:6px;
+        margin-left:4px;
+      }
     </style>
     <img id="image"/>
-    <paper-button on-click="capturePhoto"><iron-icon icon="camera-enhance"></iron-icon> capture photo </paper-buton>
-
+    <paper-button on-click="capturePhoto"><iron-icon icon="camera-enhance"></iron-icon> capture photo </paper-button>
+    <label class="hint-text">[[hintText]]</label>
     `
   }
 
-  static get is () {
+  static get is() {
     return 'tangy-photo-capture'
   }
 
-  static get properties () {
+  static get properties() {
     return {
       name: {
+        type: String,
+        value: ''
+      },
+      hintText: {
         type: String,
         value: ''
       },

--- a/input/tangy-radio-buttons.js
+++ b/input/tangy-radio-buttons.js
@@ -63,6 +63,7 @@ class TangyRadioButtons extends PolymerElement {
 
       <div class="container">
         <label for="group">[[label]]</label>
+        <label class="hint-text">[[hintText]]</label>
         <template is="dom-if" if="{{!hideHelpText}}">
           <span  class="secondary_color">[[t.selectOnlyOne]]</span>
         </template>
@@ -94,6 +95,10 @@ class TangyRadioButtons extends PolymerElement {
         value: [],
         observer: 'reflect',
         reflectToAttribute: true
+      },
+      hintText: {
+        type: String,
+        value: ''
       },
       required: {
         type: Boolean,

--- a/input/tangy-select.js
+++ b/input/tangy-select.js
@@ -37,6 +37,11 @@ class TangySelect extends PolymerElement {
         observer: 'reflect',
         reflectToAttribute: true
       },
+      hintText: {
+        type: String,
+        value: '',
+        reflectToAttribute: true
+      },
       required: {
         type: Boolean,
         value: false,
@@ -108,6 +113,7 @@ class TangySelect extends PolymerElement {
     this.querySelectorAll('option').forEach(optionEl => options.push(optionEl))
     this.$.container.innerHTML = `
       <label for="group">${this.label}</label>
+      <label class="hint-text">${this.hintText}</label>
       <div class="mdc-select">
         <select class="mdc-select__surface" value="${this.value}">
           ${ (this.secondaryLabel) ? `

--- a/input/tangy-timed.js
+++ b/input/tangy-timed.js
@@ -149,7 +149,7 @@ class TangyTimed extends PolymerElement {
         padding-top: 70px;
       }
     </style>
-
+    <label class="hint-text">[[hintText]]</label>
     <div id="container">
       
       <div id="info">
@@ -213,6 +213,11 @@ class TangyTimed extends PolymerElement {
         type: Array,
         value: [],
         observer: 'reflect',
+        reflectToAttribute: true
+      },
+      hintText: {
+        type: String,
+        value: '',
         reflectToAttribute: true
       },
       // Use value for mode. 

--- a/style/tangy-common-styles.js
+++ b/style/tangy-common-styles.js
@@ -35,6 +35,11 @@ $_documentStyleContainer.innerHTML = `
         --paper-radio-button-size: 1.5em;
         --paper-radio-button-checked-color: var(--primary-color);
       }
+      label.hint-text {
+        color: gray;
+        font-size: small;
+        font-weight: lighter;
+    }
   </style>
   </template>
   </dom-module>


### PR DESCRIPTION
## Problem/Feature
* Add `hint-text` attribute
* Closes Tangerine-Community/Tangerine#1279
## Approach/Solution
* Added `hint-text` attribute to the markup and `hintText` property to each of the elements definition
