### PR TITLE
Add dynamic tangy-select options

### DIFF
--- a/input/tangy-select.js
+++ b/input/tangy-select.js
@@ -28,9 +28,7 @@ class TangySelect extends PolymerElement {
     return {
       name: {
         type: String,
-        value: '',
-        observer: 'render',
-        reflectToAttribute: true
+        value: ''
       },
       value: {
         type: String,
@@ -41,13 +39,12 @@ class TangySelect extends PolymerElement {
       hintText: {
         type: String,
         value: '',
+        observer: 'render',
         reflectToAttribute: true
       },
       required: {
         type: Boolean,
-        value: false,
-        observer: 'render',
-        reflectToAttribute: true
+        value: false
       },
       disabled: {
         type: Boolean,
@@ -69,21 +66,15 @@ class TangySelect extends PolymerElement {
       },
       hidden: {
         type: Boolean,
-        value: false,
-        observer: 'render',
-        reflectToAttribute: true
+        value: false
       },
       invalid: {
         type: Boolean,
-        value: false,
-        observer: 'render',
-        reflectToAttribute: true
+        value: false
       },
       incomplete: {
         type: Boolean,
-        value: true,
-        observer: 'render',
-        reflectToAttribute: true
+        value: true
       }
     }
   }
@@ -103,7 +94,7 @@ class TangySelect extends PolymerElement {
       <label for="group">${this.label}</label>
       <label class="hint-text">${this.hintText}</label>
       <div class="mdc-select">
-        <select class="mdc-select__surface" value="${this.value}">
+        <select class="mdc-select__surface" value="${this.value}" ${this.disabled ? 'disabled' : ''}>
           ${ (this.secondaryLabel) ? `
             <option value="" default selected disabled>${this.secondaryLabel}</option>
           ` : ``}

--- a/input/tangy-select.js
+++ b/input/tangy-select.js
@@ -33,13 +33,11 @@ class TangySelect extends PolymerElement {
       value: {
         type: String,
         value: '',
-        observer: 'render',
         reflectToAttribute: true
       },
       hintText: {
         type: String,
         value: '',
-        observer: 'render',
         reflectToAttribute: true
       },
       required: {
@@ -49,19 +47,16 @@ class TangySelect extends PolymerElement {
       disabled: {
         type: Boolean,
         value: false,
-        observer: 'render',
         reflectToAttribute: true
       },
       label: {
         type: String,
         value: '',
-        observer: 'render',
         reflectToAttribute: true
       },
       secondaryLabel: {
         type: String,
         value: '',
-        observer: 'render',
         reflectToAttribute: true
       },
       hidden: {

--- a/input/tangy-select.js
+++ b/input/tangy-select.js
@@ -29,13 +29,13 @@ class TangySelect extends PolymerElement {
       name: {
         type: String,
         value: '',
-        observer: 'reflect',
+        observer: 'render',
         reflectToAttribute: true
       },
       value: {
         type: String,
         value: '',
-        observer: 'reflect',
+        observer: 'render',
         reflectToAttribute: true
       },
       hintText: {
@@ -46,68 +46,55 @@ class TangySelect extends PolymerElement {
       required: {
         type: Boolean,
         value: false,
-        observer: 'reflect',
+        observer: 'render',
         reflectToAttribute: true
       },
       disabled: {
         type: Boolean,
         value: false,
-        observer: 'reflect',
+        observer: 'render',
         reflectToAttribute: true
       },
       label: {
         type: String,
         value: '',
-        observer: 'reflect',
+        observer: 'render',
         reflectToAttribute: true
       },
       secondaryLabel: {
         type: String,
         value: '',
-        observer: 'reflect',
+        observer: 'render',
         reflectToAttribute: true
       },
       hidden: {
         type: Boolean,
         value: false,
-        observer: 'reflect',
+        observer: 'render',
         reflectToAttribute: true
       },
       invalid: {
         type: Boolean,
         value: false,
-        observer: 'reflect',
+        observer: 'render',
         reflectToAttribute: true
       },
       incomplete: {
         type: Boolean,
         value: true,
-        observer: 'reflect',
+        observer: 'render',
         reflectToAttribute: true
       }
     }
   }
 
-  constructor() {
-    super()
-    this.value = ''
-  }
-
   connectedCallback() {
     super.connectedCallback()
+    const observer = new MutationObserver(this.render.bind(this))
+    observer.observe(this, { attributes: true, childList: true, subtree: true })
     this.render()
-    this.reflect()
   }
   
-  reflect() {
-    let selectEl = this
-      .shadowRoot
-      .querySelector('select')
-    if (selectEl) {
-      selectEl.setProps(this.getProps())
-    }
-  }
-
   render() {
     this.$.container.innerHTML = ''
     let options = []
@@ -123,6 +110,7 @@ class TangySelect extends PolymerElement {
           ${options.map((option, i) => `
             <option 
               value="${option.value}" 
+              ${this.value === option.value ? 'selected' : ''}
             >
               ${combTranslations(option.innerHTML)}
             </option>
@@ -130,14 +118,12 @@ class TangySelect extends PolymerElement {
         </select>
       </div>
       <div class="mdc-select__bottom-line"></div>
-    
     `
-
-    this
+    this._onChangeListener = this
       .shadowRoot
       .querySelector('select')
       .addEventListener('change', this.onChange.bind(this))
-
+    this.dispatchEvent(new CustomEvent('render'))
   }
 
   onChange(event) {

--- a/test/index.html
+++ b/test/index.html
@@ -15,6 +15,7 @@
         'tangy-form-item_test.html',
         'tangy-template_test.html',
         'tangy-input-groups_test.html',
+        'tangy-select_test.html',
         'tangy-radio-button_test.html',
         'tangy-radio-buttons_test.html',
         'tangy-location_test.html',

--- a/test/tangy-select_test.html
+++ b/test/tangy-select_test.html
@@ -1,0 +1,105 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width, minimum-scale=1, initial-scale=1, user-scalable=yes">
+    <title>tangy-select test</title>
+    <script src="../node_modules/@webcomponents/webcomponentsjs/webcomponents-loader.js"></script>
+    <script src="../node_modules/redux/dist/redux.js"></script>
+    <script src="../node_modules/wct-browser-legacy/browser.js"></script>
+    <script type="module" src="../input/tangy-select.js"></script>
+  </head>
+  <body>
+     
+    <test-fixture id="TangySelectFixture">
+      <template>
+        <tangy-select name="foo" label="This is a label">
+          <option value="a">A</option>
+          <option value="b">B</option>
+          <option value="c">C</option>
+        </tangy-select>
+      </template>
+    </test-fixture>
+
+     <test-fixture id="TangySelectValueSetFixture">
+      <template>
+        <tangy-select name="foo" label="This is a label" value="b">
+          <option value="a">A</option>
+          <option value="b">B</option>
+          <option value="c">C</option>
+        </tangy-select>
+      </template>
+    </test-fixture>    
+
+    <test-fixture id="DynamicTangySelectFixture">
+      <template>
+        <tangy-select name="foo" label="This is a label">
+          <option value="a">A</option>
+          <option value="b">B</option>
+        </tangy-select>
+      </template>
+    </test-fixture>
+
+    <test-fixture id="TangySelectWithMarkupFixture">
+      <template>
+        <tangy-select name="foo" label="This is a <b>bold label</b>">
+          <option value="a">A</option>
+          <option value="b">B</option>
+          <option value="c">C</option>
+        </tangy-select>
+      </template>
+    </test-fixture>
+
+    <test-fixture id="TranslatablePlaceholderFixture">
+      <template>
+        <tangy-select name="foo" placeholder="<t-lang en>Hello</t-lang><t-lang fr>Bonjour</t-lang>">
+          <option value="a">A</option>
+          <option value="b">B</option>
+          <option value="c">C</option>
+        </tangy-select>
+      </template>
+    </test-fixture>
+
+    <script type="module">
+      import * as Polymer from '../node_modules/@polymer/polymer/polymer-legacy.js'
+      import '../input/tangy-input.js'
+      suite('tangy-input', () => {
+
+        test('should render options', () => {
+          const element = fixture('TangySelectFixture')
+          assert.equal(element.shadowRoot.querySelectorAll('option').length, 3)
+        })
+
+        test('should have value set on load', () => {
+          const element = fixture('TangySelectValueSetFixture')
+          assert.equal(element.shadowRoot.querySelector('[selected]').getAttribute('value'), 'b')
+        })
+
+        test('should update after value set', () => {
+          const element = fixture('TangySelectValueSetFixture')
+          element.value = 'c'
+          assert.equal(element.shadowRoot.querySelector('[selected]').getAttribute('value'), 'c')
+        })
+
+        test('should have label with markup', () => {
+          const element = fixture('TangySelectWithMarkupFixture')
+          assert.equal(element.shadowRoot.querySelectorAll('label b').length, 1)
+        })
+
+        test('should add an option dynamically', (done) => {
+          const element = fixture('DynamicTangySelectFixture');
+          element.addEventListener('render', () => {
+            assert.equal(element.shadowRoot.querySelectorAll('option').length, 3)
+            done()
+          })
+          element.innerHTML = `
+            ${element.innerHTML}
+            <option value="c">C</option>
+          `
+        })
+
+      })
+    </script>
+
+  </body>
+</html>

--- a/test/tangy-select_test.html
+++ b/test/tangy-select_test.html
@@ -81,6 +81,12 @@
           assert.equal(element.shadowRoot.querySelector('[selected]').getAttribute('value'), 'c')
         })
 
+        test('should disable', () => {
+          const element = fixture('TangySelectFixture')
+          element.setAttribute('disabled', true)
+          assert.equal(element.shadowRoot.querySelector('select').hasAttribute('disabled'), true)
+        })
+
         test('should have label with markup', () => {
           const element = fixture('TangySelectWithMarkupFixture')
           assert.equal(element.shadowRoot.querySelectorAll('label b').length, 1)

--- a/test/tangy-select_test.html
+++ b/test/tangy-select_test.html
@@ -75,16 +75,22 @@
           assert.equal(element.shadowRoot.querySelector('[selected]').getAttribute('value'), 'b')
         })
 
-        test('should update after value set', () => {
+        test('should update after value set', (done) => {
           const element = fixture('TangySelectValueSetFixture')
+          element.addEventListener('render', () => {
+            assert.equal(element.shadowRoot.querySelector('[selected]').getAttribute('value'), 'c')
+            done()
+          })
           element.value = 'c'
-          assert.equal(element.shadowRoot.querySelector('[selected]').getAttribute('value'), 'c')
         })
 
-        test('should disable', () => {
+        test('should disable', (done) => {
           const element = fixture('TangySelectFixture')
           element.setAttribute('disabled', true)
-          assert.equal(element.shadowRoot.querySelector('select').hasAttribute('disabled'), true)
+          element.addEventListener('render', () => {
+            assert.equal(element.shadowRoot.querySelector('select').hasAttribute('disabled'), true)
+            done()
+          })
         })
 
         test('should have label with markup', () => {


### PR DESCRIPTION
This allows `<option>` elements to be added to `<tangy-select>` after first render. This is useful for situations where other component libraries like Angular's first put the `<tangy-select>` in the DOM and then iteratively add `<option>` elements using an `*ngFor`. While I was at it I also wrote a basic set of tests for this component.