### PR TITLE
Add support for eftouch multi-select attribute and multiple values of correct options

### DIFF
--- a/input/tangy-eftouch.js
+++ b/input/tangy-eftouch.js
@@ -261,33 +261,41 @@ export class TangyEftouch extends PolymerElement {
           ${option.hasAttribute('correct') ? 'correct' : ''}
           ${
             this.hasAttribute('multi-select')
-              ? this.value.selection.includes(option.value) ? `selected` : ``
-              : this.value.selection === option.value ? `selected` : ``
+              ? !option.hasAttribute('disabled') && this.value.selection.includes(option.value) ? `selected` : ``
+              : !option.hasAttribute('disabled') && this.value.selection === option.value ? `selected` : ``
           }
           style="
             display: inline-block;
             width:${Math.floor((option.getAttribute('width')/100)*this.width)}px;
             height:${Math.floor((option.getAttribute('height')/100)*(this.height-60))}px;
           ">
-          ${option.getAttribute('src') ? `
-            <img 
-              value="${option.value}" 
-              
+          <img 
+            ${option.hasAttribute('disabled') ? `disabled` : ''}
+            value="${option.value}" 
+            ${!option.hasAttribute('src') || option.getAttribute('src') === '' ? `
+              disabled
+              style="
+                height: 100%;
+                width: 100%;
+              " 
+              src="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mNgYAAAAAMAASsJTYQAAAAASUVORK5CYII="
+            ` : `
               style="
                 max-height: 100%;
                 max-width: 100%;
-              " 
-              src="${option.getAttribute('src')}">
-          ` : ``}
+              "
+              src="${option.getAttribute('src')}"
+            `}
+          >
         </span>
       `).join('')}
       </div>
     `
-    this.shadowRoot.querySelectorAll('img').forEach(el => el.addEventListener('click', _ => this.onSelection(_.target)))
+    this.shadowRoot.querySelectorAll('img:not([disabled])').forEach(el => el.addEventListener('click', _ => this.onSelection(_.target)))
   }
 
   onSelection(target) {
-    if (this.disabled === true) return
+    if (this.disabled === true || target.hasAttribute('disabled')) return
     if (this.hasAttribute('no-corrections') && this.value && this.value.correct === false) {
       // Do nothing.
       return

--- a/input/tangy-eftouch.js
+++ b/input/tangy-eftouch.js
@@ -215,19 +215,19 @@ export class TangyEftouch extends PolymerElement {
         }
         #messages-box {
           height: 60px;
-          /* background: red; */
         }
-        #options-box {
-          /* background: #EEE; */
+        #cell img {
+          border: #FFF solid 5px;
+        }
+        #cell[selected] img {
+          border: red solid 5px;
         }
         #cell {
+          padding: 5px;
           text-align: center;
         }
-        #cell[selected] {
-          background: lightgreen;
-        }
-        :host([highlight-correct]) #cell[correct] {
-          background: yellow;
+        :host([highlight-correct]) #cell[correct] img {
+          border: yellow solid 5px;
         }
 
       </style>

--- a/input/tangy-eftouch.js
+++ b/input/tangy-eftouch.js
@@ -56,6 +56,11 @@ export class TangyEftouch extends PolymerElement {
         value: '',
         reflectToAttribute: true
       },
+      openSound: {
+        type: String,
+        value: '',
+        reflectToAttribute: true
+      },
       transitionDelay: {
         type: Number,
         value: 0,
@@ -134,6 +139,7 @@ export class TangyEftouch extends PolymerElement {
 
   connectedCallback () {
     super.connectedCallback()
+    if (this.openSound) new Audio(this.openSound).play()
     if (!this.width) {
       this.width = document.documentElement.offsetWidth
     }

--- a/test/tangy-eftouch_test.html
+++ b/test/tangy-eftouch_test.html
@@ -115,6 +115,19 @@
       </template>
     </test-fixture>
 
+    <test-fixture id="EFTouchOpenSoundFixture">
+      <template>
+        <tangy-eftouch name="animal_selection" open-sound="assets/sounds/pop.mp3" label="Which is your favorite animal?">
+            <option width=30 height=50 src="assets/images/bird.png" value="bird"></option>
+            <option width=30 height=50 src="assets/images/cat.png" value="cat"></option>
+            <option width=30 height=50 src="assets/images/cow.png" value="cow"></option>
+            <option width=30 height=50 src="assets/images/dog.png" value="dog"></option>
+            <option width=30 height=50 src="assets/images/fish.png" value="fish"></option>
+            <option width=30 height=50 src="assets/images/pig.png" value="pig"></option>
+          </tangy-eftouch>
+      </template>
+    </test-fixture>
+
     <test-fixture id="EFTouchWarningFixture">
       <template>
         <tangy-eftouch warning-time=100 warning-message="You are running out of time!" value="fruit_selection" label="What is your favorite fruit?">
@@ -312,6 +325,14 @@
           assert(element.shadowRoot.querySelectorAll('img').length, 6)
         })
 
+        test('should make an open sound', () => { 
+          const element = fixture('EFTouchOpenSoundFixture')
+          // No way to programatically test this...
+          debugger
+        })
+
+
+
         test('should give warning message after hitting warning time', (done) => { 
           const element = fixture('EFTouchWarningFixture')
           setTimeout(() => {
@@ -342,6 +363,7 @@
             done()
           }, 105)
         })
+
         test('should auto-progress at time limit', (done) => { 
           const element = fixture('EFTouchTimeLimitAutoProgressFixture')
           let eventDidFire = false
@@ -385,7 +407,7 @@
           assert.equal(element.value.correct, false)
           element.shadowRoot.querySelectorAll('img')[1].click()
           assert.equal(element.value.correct, true)
-        });
+        })
         
         test('should not allow proceeding without selection when required', () => {
           const element = fixture('EFTouchRequiredFixture');

--- a/test/tangy-eftouch_test.html
+++ b/test/tangy-eftouch_test.html
@@ -102,6 +102,19 @@
       </template>
     </test-fixture>
 
+    <test-fixture id="EFTouchTransitionNoAutoProgressFixture">
+      <template>
+        <tangy-eftouch 
+          transition-message="Thank you for your input. Click next."
+          name="fruit_selection"
+          label="What is your favorite fruit?"
+          >
+          <option width=30 height=50 value="orange" src="assets/images/cat.png"></option>
+          <option width=30 height=50 value="banana" src="assets/images/cat.png"></option>
+        </tangy-eftouch>
+      </template>
+    </test-fixture>
+
     <test-fixture id="EFTouchWarningFixture">
       <template>
         <tangy-eftouch warning-time=100 warning-message="You are running out of time!" value="fruit_selection" label="What is your favorite fruit?">
@@ -118,10 +131,15 @@
     <test-fixture id="EFTouchTimeLimitFixture">
       <template>
         <tangy-eftouch time-limit=100 value="fruit_selection" label="What is your favorite fruit?">
-          <option value="orange" src="assets/images/cat.png"></option>
-          <option value="banana" src="assets/images/cat.png"></option>
-          <option value="tangerine" src="assets/images/cat.png"></option>
-          <option value="cantalope" src="assets/images/cat.png"></option>
+          <option value="cherry" src="assets/images/cat.png"></option>
+          <option value="kiwi" src="assets/images/cat.png"></option>
+        </tangy-eftouch>
+      </template>
+    </test-fixture>
+
+    <test-fixture id="EFTouchTimeLimitAutoProgressFixture">
+      <template>
+        <tangy-eftouch time-limit=100 auto-progress value="fruit_selection" label="What is your favorite fruit?">
           <option value="cherry" src="assets/images/cat.png"></option>
           <option value="kiwi" src="assets/images/cat.png"></option>
         </tangy-eftouch>
@@ -141,27 +159,11 @@
       </template>
     </test-fixture>
 
-    <test-fixture id="EFTouchCorrectFixture">
-      <template>
-        <tangy-eftouch incorrect-message="You chose the wrong option. Try again." name="fruit_selection" label="What is your favorite fruit?">
-          <option value="orange" correct src="assets/images/cat.png"></option>
-          <option value="banana" correct src="assets/images/cat.png"></option>
-          <option value="tangerine" src="assets/images/cat.png"></option>
-          <option value="cantalope" src="assets/images/cat.png"></option>
-          <option value="cherry" src="assets/images/cat.png"></option>
-          <option value="kiwi" src="assets/images/cat.png"></option>
-        </tangy-eftouch>
-      </template>
-    </test-fixture>
-
     <test-fixture id="EFTouchWithCorrectFixture">
       <template>
         <tangy-eftouch 
           name="animal_selection" 
           label="Which animal can breath under water?"
-          incorrect-message="You chose the wrong option. Try again."
-          transition-message="Great job!"
-          transition-delay="1000"
           >
             <option width=30 height=50 src="assets/images/bird.png" value="bird"></option>
             <option width=30 height=50 src="assets/images/cat.png" value="cat"></option>
@@ -182,6 +184,63 @@
           </tangy-eftouch>
       </template>
     </test-fixture>
+
+    <test-fixture id="EFTouchRequiredFixture">
+      <template>
+        <tangy-eftouch name="animal_selection" label="Which animals can not breath under water?" required>
+            <option width=30 height=50 src="assets/images/cow.png" value="cow"></option>
+            <option width=30 height=50 src="assets/images/dog.png" value="dog"></option>
+            <option width=30 height=50 src="assets/images/fish.png" value="fish"></option>
+          </tangy-eftouch>
+      </template>
+    </test-fixture>
+
+    <test-fixture id="EFTouchRequiredCorrectFixture">
+      <template>
+        <tangy-eftouch name="animal_selection" label="Which animals can not breath under water?" required-correct>
+            <option width=30 height=50 src="assets/images/cow.png" value="cow" correct></option>
+            <option width=30 height=50 src="assets/images/dog.png" value="dog"></option>
+            <option width=30 height=50 src="assets/images/fish.png" value="fish"></option>
+          </tangy-eftouch>
+      </template>
+    </test-fixture>
+
+    <test-fixture id="EFTouchHighlightCorrectFixture">
+      <template>
+        <tangy-eftouch name="animal_selection" label="Which animals can not breath under water?" if-incorrect-then-highlight-correct>
+            <option width=30 height=50 src="assets/images/cow.png" value="cow" correct></option>
+            <option width=30 height=50 src="assets/images/dog.png" value="dog"></option>
+            <option width=30 height=50 src="assets/images/fish.png" value="fish"></option>
+          </tangy-eftouch>
+      </template>
+    </test-fixture>
+
+    <test-fixture id="EFTouchIncorrectMessageFixture">
+      <template>
+        <tangy-eftouch 
+          name="animal_selection" 
+          label="Which animal can breath under water?"
+          incorrect-message="You chose the wrong option. Try again."
+          >
+            <option width=30 height=50 src="assets/images/fish.png" value="fish" correct></option>
+            <option width=30 height=50 src="assets/images/pig.png" value="pig"></option>
+          </tangy-eftouch>
+      </template>
+    </test-fixture>
+
+    <test-fixture id="EFTouchNoCorrectionFixture">
+      <template>
+        <tangy-eftouch 
+          name="animal_selection" 
+          label="Which animal can breath under water?"
+          no-corrections
+          >
+            <option width=30 height=50 src="assets/images/dog.png" value="dog"></option>
+            <option width=30 height=50 src="assets/images/fish.png" value="fish" correct></option>
+          </tangy-eftouch>
+      </template>
+    </test-fixture>
+
 
     <script type="module">
       import * as Polymer from '../node_modules/@polymer/polymer/polymer-legacy.js'
@@ -216,6 +275,16 @@
           assert.equal(element.value.selection, 'bird')
           assert.equal(element.value.startTime !== 0, true)
           assert.equal(element.value.selectionTime !== 0, true)
+        })
+
+        test('should disable', () => { 
+          const element = fixture('EFTouchFixture');
+          // @TODO Should be 'orange'. There is a bug deeper down causing radio button labels to be names.
+          element.shadowRoot.querySelectorAll('img')[0].click()
+          assert.equal(element.value.selection, 'bird')
+          element.disabled = true
+          element.shadowRoot.querySelectorAll('img')[1].click()
+          assert.equal(element.value.selection, 'bird')
         })
 
         test('should auto-progress after selection', () => {
@@ -256,8 +325,15 @@
           assert.equal(element.hasAttribute('transition-triggered'), true)
         });
 
-        test('should transition at time limit', (done) => { 
+        test('should disable at time limit', (done) => { 
           const element = fixture('EFTouchTimeLimitFixture')
+          setTimeout(() => {
+            assert.equal(element.disabled, true)
+            done()
+          }, 105)
+        })
+        test('should auto-progress at time limit', (done) => { 
+          const element = fixture('EFTouchTimeLimitAutoProgressFixture')
           let eventDidFire = false
           element.addEventListener('next', () => {
             eventDidFire = true
@@ -265,9 +341,14 @@
           setTimeout(() => {
             assert.equal(eventDidFire, true)
             done()
-          }, 101)
+          }, 105)
           assert.equal(eventDidFire, false)
         });
+
+        test('should show transition message but no auto progress', () => {
+          const element = fixture('EFTouchTransitionNoAutoProgressFixture')
+          element.shadowRoot.querySelectorAll('img')[0].click()
+        })
 
         test('should allow multi-select', () => { 
           const element = fixture('EFTouchMultiSelectFixture');
@@ -278,7 +359,6 @@
           element.shadowRoot.querySelectorAll('img')[4].click()
           assert(element.shadowRoot.querySelectorAll('[selected]').length, 1)
           assert(element.value.selection.length, 1)
-
         });
 
         test('should have value of correctness', () => { 
@@ -297,19 +377,50 @@
           assert.equal(element.value.correct, true)
         });
         
-        test('should not allow proceeding without correct selection when required (auto progress and manual)')
-        test('should show transition message but not auto progress')
-        test('should not allow correction (important in training, not demonstrating)')
-        test('should not allow proceeding without selection when required (auto progress and manual)')
-        test('should proceed after correction')
+        test('should not allow proceeding without selection when required', () => {
+          const element = fixture('EFTouchRequiredFixture');
+          assert.equal(element.validate(), false)
+          element.shadowRoot.querySelectorAll('img')[1].click()
+          assert.equal(element.validate(), true)
+        })
+
+        test('should not allow proceeding without correct selection when required', () => {
+          const element = fixture('EFTouchRequiredCorrectFixture');
+          element.shadowRoot.querySelectorAll('img')[2].click()
+          assert.equal(element.validate(), false)
+          element.shadowRoot.querySelectorAll('img')[0].click()
+          assert.equal(element.validate(), true)
+        })
+
+        test('when incorrect option selected, highlight correct option', () => {
+          const element = fixture('EFTouchHighlightCorrectFixture');
+          element.shadowRoot.querySelectorAll('img')[2].click()
+          assert.equal(element.hasAttribute('highlight-correct'), true)
+        })
+
+        test('should show message when incorrect', () => {
+          const element = fixture('EFTouchIncorrectMessageFixture');
+          element.shadowRoot.querySelectorAll('img')[1].click()
+          assert.equal(!!element.shadowRoot.querySelector('#incorrect'), true)
+          element.shadowRoot.querySelectorAll('img')[0].click()
+          assert.equal(!!element.shadowRoot.querySelector('#incorrect'), false)
+        })
+
+        test('should not allow correction', () => {
+          const element = fixture('EFTouchNoCorrectionFixture');
+          element.shadowRoot.querySelectorAll('img')[0].click()
+          assert.equal(element.value.selection, 'dog')
+          assert.equal(element.value.correct, false)
+          element.shadowRoot.querySelectorAll('img')[1].click()
+          assert.equal(element.value.selection, 'dog')
+          assert.equal(element.value.correct, false)
+        })
+
         test('should not show warning message if a selection is made')
-        test('when incorrect option selected, should instruct to provide correction and highlight correct option and not proceed until corrected')
-        test('should instruct to provide correction and not show correct or incorrect options')
         test('should be able to skip given correctness of prior entry in a set of items')
         test('can group questions to be able to calculate % correct in a group')
         test('should leave fullscreen after 5 times pressing x button');
         test('should resume')
-        test('should disable')
 
       })
 

--- a/test/tangy-eftouch_test.html
+++ b/test/tangy-eftouch_test.html
@@ -287,6 +287,16 @@
           assert.equal(element.value.selection, 'bird')
         })
 
+        test('should resume', () => {
+          const element = fixture('EFTouchFixture');
+          element.value = {
+            "startTime": 1562069141106,
+            "selectionTime": 1562069146071,
+            "selection": "bird"
+          }
+          assert.equal(element.shadowRoot.querySelectorAll('[selected]').length, 1)
+        })
+
         test('should auto-progress after selection', () => {
           const element = fixture('EFTouchAutoProgressFixture');
           let eventDidFire = false
@@ -420,7 +430,6 @@
         test('should be able to skip given correctness of prior entry in a set of items')
         test('can group questions to be able to calculate % correct in a group')
         test('should leave fullscreen after 5 times pressing x button');
-        test('should resume')
 
       })
 

--- a/test/tangy-eftouch_test.html
+++ b/test/tangy-eftouch_test.html
@@ -255,7 +255,7 @@
           assert.equal(eventDidFire, false)
           assert.equal(element.hasAttribute('transition-triggered'), true)
         });
-        
+
         test('should transition at time limit', (done) => { 
           const element = fixture('EFTouchTimeLimitFixture')
           let eventDidFire = false
@@ -275,6 +275,10 @@
           element.shadowRoot.querySelectorAll('img')[4].click()
           assert(element.shadowRoot.querySelectorAll('[selected]').length, 2)
           assert(element.value.selection.length, 2)
+          element.shadowRoot.querySelectorAll('img')[4].click()
+          assert(element.shadowRoot.querySelectorAll('[selected]').length, 1)
+          assert(element.value.selection.length, 1)
+
         });
 
         test('should have value of correctness', () => { 

--- a/test/tangy-eftouch_test.html
+++ b/test/tangy-eftouch_test.html
@@ -128,9 +128,22 @@
       </template>
     </test-fixture>
 
+    <test-fixture id="EFTouchMultiSelectFixture">
+      <template>
+        <tangy-eftouch name="fruit_selection" multi-select label="What is your favorite fruit?">
+          <option width=30 height=50 value="orange" src="assets/images/cat.png"></option>
+          <option width=30 height=50 value="banana" src="assets/images/cat.png"></option>
+          <option width=30 height=50 value="tangerine" src="assets/images/cat.png"></option>
+          <option width=30 height=50 value="cantalope" src="assets/images/cat.png"></option>
+          <option width=30 height=50 value="cherry" src="assets/images/cat.png"></option>
+          <option width=30 height=50 value="kiwi" src="assets/images/cat.png"></option>
+        </tangy-eftouch>
+      </template>
+    </test-fixture>
+
     <test-fixture id="EFTouchCorrectFixture">
       <template>
-        <tangy-eftouch incorrect-message="You chose the wrong option. Try again." value="fruit_selection" label="What is your favorite fruit?">
+        <tangy-eftouch incorrect-message="You chose the wrong option. Try again." name="fruit_selection" label="What is your favorite fruit?">
           <option value="orange" correct src="assets/images/cat.png"></option>
           <option value="banana" correct src="assets/images/cat.png"></option>
           <option value="tangerine" src="assets/images/cat.png"></option>
@@ -138,6 +151,35 @@
           <option value="cherry" src="assets/images/cat.png"></option>
           <option value="kiwi" src="assets/images/cat.png"></option>
         </tangy-eftouch>
+      </template>
+    </test-fixture>
+
+    <test-fixture id="EFTouchWithCorrectFixture">
+      <template>
+        <tangy-eftouch 
+          name="animal_selection" 
+          label="Which animal can breath under water?"
+          incorrect-message="You chose the wrong option. Try again."
+          transition-message="Great job!"
+          transition-delay="1000"
+          >
+            <option width=30 height=50 src="assets/images/bird.png" value="bird"></option>
+            <option width=30 height=50 src="assets/images/cat.png" value="cat"></option>
+            <option width=30 height=50 src="assets/images/cow.png" value="cow"></option>
+            <option width=30 height=50 src="assets/images/dog.png" value="dog"></option>
+            <option width=30 height=50 src="assets/images/fish.png" value="fish" correct></option>
+            <option width=30 height=50 src="assets/images/pig.png" value="pig"></option>
+          </tangy-eftouch>
+      </template>
+    </test-fixture>
+
+    <test-fixture id="EFTouchWithMultipleCorrectFixture">
+      <template>
+        <tangy-eftouch multi-select name="animal_selection" label="Which animals can not breath under water?">
+            <option width=30 height=50 src="assets/images/cow.png" value="cow" correct></option>
+            <option width=30 height=50 src="assets/images/dog.png" value="dog" correct></option>
+            <option width=30 height=50 src="assets/images/fish.png" value="fish"></option>
+          </tangy-eftouch>
       </template>
     </test-fixture>
 
@@ -213,7 +255,7 @@
           assert.equal(eventDidFire, false)
           assert.equal(element.hasAttribute('transition-triggered'), true)
         });
-
+        
         test('should transition at time limit', (done) => { 
           const element = fixture('EFTouchTimeLimitFixture')
           let eventDidFire = false
@@ -227,7 +269,30 @@
           assert.equal(eventDidFire, false)
         });
 
-        test('should have value of correctness');
+        test('should allow multi-select', () => { 
+          const element = fixture('EFTouchMultiSelectFixture');
+          element.shadowRoot.querySelectorAll('img')[0].click()
+          element.shadowRoot.querySelectorAll('img')[4].click()
+          assert(element.shadowRoot.querySelectorAll('[selected]').length, 2)
+          assert(element.value.selection.length, 2)
+        });
+
+        test('should have value of correctness', () => { 
+          const element = fixture('EFTouchWithCorrectFixture');
+          element.shadowRoot.querySelectorAll('img')[0].click()
+          assert.equal(element.value.correct, false)
+          element.shadowRoot.querySelectorAll('img')[4].click()
+          assert.equal(element.value.correct, true)
+        });
+
+        test('should have value of correctness with multi-select', () => { 
+          const element = fixture('EFTouchWithMultipleCorrectFixture');
+          element.shadowRoot.querySelectorAll('img')[0].click()
+          assert.equal(element.value.correct, false)
+          element.shadowRoot.querySelectorAll('img')[1].click()
+          assert.equal(element.value.correct, true)
+        });
+        
         test('should not allow proceeding without correct selection when required (auto progress and manual)')
         test('should show transition message but not auto progress')
         test('should not allow correction (important in training, not demonstrating)')

--- a/test/tangy-eftouch_test.html
+++ b/test/tangy-eftouch_test.html
@@ -23,6 +23,16 @@
       </template>
     </test-fixture>
 
+    <test-fixture id="EFTouchDisabledOptionFixture">
+      <template>
+        <tangy-eftouch name="animal_selection" label="Which is your favorite animal?">
+            <option width=30 height=50 src="assets/images/bird.png" value="bird"></option>
+            <option width=30 height=50 disabled></option>
+            <option width=30 height=50 src="assets/images/cow.png" value="cow"></option>
+          </tangy-eftouch>
+      </template>
+    </test-fixture>
+
     <test-fixture id="UnusualLayoutFixture">
       <template>
           <tangy-eftouch name="cat_selection" label="Which is your favorite cat?">
@@ -310,6 +320,13 @@
           assert.equal(element.shadowRoot.querySelectorAll('[selected]').length, 1)
         })
 
+        test('should have disabled option that cannot be selected', () => {
+          const element = fixture('EFTouchDisabledOptionFixture');
+          element.shadowRoot.querySelectorAll('img')[0].click()
+          element.shadowRoot.querySelectorAll('img')[1].click()
+          assert.equal(element.value.selection, 'bird')
+        })
+
         test('should auto-progress after selection', () => {
           const element = fixture('EFTouchAutoProgressFixture');
           let eventDidFire = false
@@ -328,10 +345,7 @@
         test('should make an open sound', () => { 
           const element = fixture('EFTouchOpenSoundFixture')
           // No way to programatically test this...
-          debugger
         })
-
-
 
         test('should give warning message after hitting warning time', (done) => { 
           const element = fixture('EFTouchWarningFixture')


### PR DESCRIPTION
New 'multi-select` attribute on `<tangy-eftouch>` allows you to select multiple options. If enabled `TangyEftouchElement.value.selection` will be of type array. You may also now define which options are "correct" using the `correct` attribute on option elements. Having an `option` element with `correct` attribute will then cause `TangyEftouchElement.value.correct` to be `true` or `false`. Note, if `mutli-select` is enabled, all options marked as correct are required in order for `TangyEftouchElement.value.correct` to be true.

```html
        <tangy-eftouch multi-select name="animal_selection" label="Which animals can not breath under water?">
            <option width=30 height=50 src="assets/images/cow.png" value="cow" correct></option>
            <option width=30 height=50 src="assets/images/dog.png" value="dog" correct></option>
            <option width=30 height=50 src="assets/images/fish.png" value="fish"></option>
          </tangy-eftouch>
```