### PR TITLE
Add fullscreen enter/exit button

### DIFF
--- a/tangy-form-item.js
+++ b/tangy-form-item.js
@@ -72,24 +72,23 @@ export class TangyFormItem extends PolymerElement {
         :host([hidden]) {
           display: none;
         }
-        :host([fullscreen]) paper-card {
-          width: 100%;
-          max-width: 100% !important;
-          height: 100vh;
-        }
 
        /*
         * Fullscreen 
         */
-
-        :host([fullscreen]) {
+        :host([fullscreen-enabled]) paper-card {
+          width: 100%;
+          max-width: 100% !important;
+          height: 100vh;
+        }
+        :host([fullscreen-enabled]) {
           margin: 0px
         }
-        :host([fullscreen]) paper-card  {
+        :host([fullscreen-enabled]) paper-card  {
           padding-top: 53px;
           overflow: scroll;
         }
-        :host([fullscreen]) .card-actions {
+        :host([fullscreen-enabled]) .card-actions {
           position: fixed;
           top: 0px;
           width: 100%;
@@ -97,36 +96,36 @@ export class TangyFormItem extends PolymerElement {
           padding: 0px;
           margin: 0px;
         }
-        :host([fullscreen]) paper-button {
+        :host([fullscreen-enabled]) paper-button {
           background: white;
           color: grey;
         }
-        :host([fullscreen]) paper-button#complete {
+        :host([fullscreen-enabled]) paper-button#complete {
           float: right;
           margin: 15px;
           background: green;
           color: white; 
         }
-        :host([fullscreen]) paper-button#complete paper-button {
+        :host([fullscreen-enabled]) paper-button#complete paper-button {
           display: none;
         }
-        :host([fullscreen]) label.heading {
+        :host([fullscreen-enabled]) label.heading {
           display: none;
         }
-        :host([fullscreen]) .card-content {
+        :host([fullscreen-enabled]) .card-content {
           padding-top: 0px;
         }
         :host(:not([fullscreen])) #enable-fullscreen,
         :host(:not([fullscreen])) #disable-fullscreen,
         :host([fullscreen]:not([fullscreen-enabled])) #disable-fullscreen,
         :host([fullscreen]):host([fullscreen-enabled]) #enable-fullscreen
-         {
+        {
           display: none;
         }
         #disable-fullscreen,
-        #enable-fullscreen
+        #enable-fullscreen 
         {
-          position: fixed;
+          position: absolute;
           left: 50%;
           transform: translateX(-50%);  
         }

--- a/tangy-form-item.js
+++ b/tangy-form-item.js
@@ -116,6 +116,21 @@ export class TangyFormItem extends PolymerElement {
         :host([fullscreen]) .card-content {
           padding-top: 0px;
         }
+        :host(:not([fullscreen])) #enable-fullscreen,
+        :host(:not([fullscreen])) #disable-fullscreen,
+        :host([fullscreen]:not([fullscreen-enabled])) #disable-fullscreen,
+        :host([fullscreen]):host([fullscreen-enabled]) #enable-fullscreen
+         {
+          display: none;
+        }
+        #disable-fullscreen,
+        #enable-fullscreen
+        {
+          position: fixed;
+          left: 50%;
+          transform: translateX(-50%);  
+        }
+
 
         /*
         * Action Buttons
@@ -171,6 +186,12 @@ export class TangyFormItem extends PolymerElement {
           <div id="content"></div>
         </div>
         <div class="card-actions">
+          <paper-button id="disable-fullscreen" on-click="onExitFullscreenClick" >
+            <iron-icon icon="fullscreen-exit"></iron-icon>
+          </paper-button>
+          <paper-button id="enable-fullscreen" on-click="onEnterFullscreenClick" >
+            <iron-icon icon="fullscreen"></iron-icon>
+          </paper-button>
           <template is="dom-if" if="{{!hideButtons}}">
             <paper-button id="open" on-click="onOpenButtonPress">[[t.open]]</paper-button>
             <template is="dom-if" if="{{!locked}}">
@@ -245,6 +266,11 @@ export class TangyFormItem extends PolymerElement {
         reflectToAttribute: true
       },
       fullscreen: {
+        type: Boolean,
+        value: false,
+        reflectToAttribute: true
+      },
+      fullscreenEnabled: {
         type: Boolean,
         value: false,
         reflectToAttribute: true
@@ -558,6 +584,14 @@ export class TangyFormItem extends PolymerElement {
       this.fireHook('on-change')
       return true
     }
+  }
+
+  onExitFullscreenClick() {
+    this.dispatchEvent(new CustomEvent('exit-fullscreen', { bubbles: true }))
+  }
+
+  onEnterFullscreenClick() {
+    this.dispatchEvent(new CustomEvent('enter-fullscreen', { bubbles: true }))
   }
 
   next() {

--- a/tangy-form-reducer.js
+++ b/tangy-form-reducer.js
@@ -297,6 +297,24 @@ const tangyFormReducer = function (state = initialState, action) {
       })
       return newState
 
+    case 'ENTER_FULLSCREEN':
+      return {
+        ...state,
+        fullscreenEnabled: true,
+        items: state.items.map(item => {
+          return { ...item, fullscreenEnabled: true}
+        })
+      }
+
+    case 'EXIT_FULLSCREEN':
+      return {
+        ...state,
+        fullscreenEnabled: false,
+        items: state.items.map(item => {
+          return { ...item, fullscreenEnabled: false}
+        })
+      }
+
     default: 
       return state
   }

--- a/tangy-form.js
+++ b/tangy-form.js
@@ -406,6 +406,13 @@ export class TangyForm extends PolymerElement {
         this.newResponse()
       }
     })
+
+    this.addEventListener('enter-fullscreen', () => {
+      this.store.dispatch({type: 'ENTER_FULLSCREEN'})
+    })
+    this.addEventListener('exit-fullscreen', () => {
+      this.store.dispatch({type: 'EXIT_FULLSCREEN'})
+    })
     
   }
 
@@ -543,10 +550,13 @@ export class TangyForm extends PolymerElement {
       this.dispatchEvent(new CustomEvent('ALL_ITEMS_CLOSED'))
     }
 
-    if (this.previousState.form.fullscreen && !state.form.fullscreen) {
-      if(document.webkitExitFullscreen) document.webkitExitFullscreen()
-      if(document.exitFullscreen) document.exitFullscreen()
-      this.removeEventListener('click', this.enableFullscreen, true)
+    if (state.form.fullscreen) {
+      if (!this.previousState.fullscreenEnabled && state.fullscreenEnabled) {
+        this.enableFullscreen()
+      }
+      else if (this.previousState.fullscreenEnabled && !state.fullscreenEnabled) {
+        this.disableFullscreen()
+      }
     }
 
     // Stash as previous state.
@@ -623,6 +633,12 @@ export class TangyForm extends PolymerElement {
     let state = this.store.getState()
     let item = state.items.find(item => item.open)
     this.store.dispatch({ type: 'ITEM_NEXT', itemId: item.id })
+  }
+
+  disableFullscreen() {
+    if(document.webkitExitFullscreen) document.webkitExitFullscreen()
+    if(document.exitFullscreen) document.exitFullscreen()
+    this.removeEventListener('click', this.enableFullscreen, true)
   }
 
   enableFullscreen() {


### PR DESCRIPTION
On a `<tangy-form fullscreen>` fullscreen enabled tangy form, this PR adds an "enable fullscreen" button in the action bar.
<img width="577" alt="Screen Shot 2019-07-18 at 3 28 54 PM" src="https://user-images.githubusercontent.com/156575/61486173-d49cfc00-a970-11e9-9db1-5efda9d91d5b.png">
When full screen is enabled, a "disable fullscreen" button appears.
<img width="493" alt="Screen Shot 2019-07-18 at 3 29 18 PM" src="https://user-images.githubusercontent.com/156575/61486176-d5ce2900-a970-11e9-951f-bbaeb4a79a2a.png">

To pull this off, I had to refactor how fullscreen enables. There is a new attribute that gets applied to items now when fullscreen enables, the `fullscreen-enabled` attribute you can see which gets applied in the new actions in the reducer. The UX here should be more predicatable as there was no call to action before on going fullscreen, it would just go fullscreen on the first touch anywhere in the form. If you exited, you would then have no way to get back. Ideally there might be a way to go fullscreen on form open, but this is a restriction of browsers which require a user action to go fullscreen. For the best perhaps.