### PR TITLE
Enable fullscreen cancel taps 1493

### DIFF
--- a/tangy-form-item.js
+++ b/tangy-form-item.js
@@ -343,8 +343,8 @@ export class TangyFormItem extends PolymerElement {
         reflectToAttribute: true
       },
       exitClicks: {
-        type: Boolean,
-        value: false,
+        type: Number,
+        value: undefined,
         reflectToAttribute: true
       }
     };

--- a/tangy-form-item.js
+++ b/tangy-form-item.js
@@ -592,8 +592,8 @@ export class TangyFormItem extends PolymerElement {
   }
 
   onExitFullscreenClick() {
-    this._exitClicks = this._exitClicks ? 1 : this._exitClicks + 1
-    if ((!this.hasAttribute('exit-clicks')) || (this.hasAttribute('exit-clicks') && this.exitClicks >= parseInt(this.getAttribute('exit-clicks')))) {
+    this._exitClicks = isNaN(this._exitClicks) ? 1 : this._exitClicks + 1
+    if ((!this.hasAttribute('exit-clicks')) || (this.hasAttribute('exit-clicks') && this._exitClicks >= parseInt(this.getAttribute('exit-clicks')))) {
       this.dispatchEvent(new CustomEvent('exit-fullscreen', { bubbles: true }))
     }
   }

--- a/tangy-form-item.js
+++ b/tangy-form-item.js
@@ -341,8 +341,12 @@ export class TangyFormItem extends PolymerElement {
         type: Number,
         value: undefined,
         reflectToAttribute: true
+      },
+      exitClicks: {
+        type: Boolean,
+        value: false,
+        reflectToAttribute: true
       }
-
     };
   }
 
@@ -589,7 +593,7 @@ export class TangyFormItem extends PolymerElement {
 
   onExitFullscreenClick() {
     this._exitClicks = this._exitClicks ? 1 : this._exitClicks + 1
-    if ((!this.hasAttribute('exit-clicks')) || (this.hasAttribute('exit-clicks') && exitClicks >= parseInt(this.getAttribute('exit-clicks')))) {
+    if ((!this.hasAttribute('exit-clicks')) || (this.hasAttribute('exit-clicks') && this.exitClicks >= parseInt(this.getAttribute('exit-clicks')))) {
       this.dispatchEvent(new CustomEvent('exit-fullscreen', { bubbles: true }))
     }
   }

--- a/tangy-form-item.js
+++ b/tangy-form-item.js
@@ -588,7 +588,10 @@ export class TangyFormItem extends PolymerElement {
   }
 
   onExitFullscreenClick() {
-    this.dispatchEvent(new CustomEvent('exit-fullscreen', { bubbles: true }))
+    this._exitClicks = this._exitClicks ? 1 : this._exitClicks + 1
+    if ((!this.hasAttribute('exit-clicks')) || (this.hasAttribute('exit-clicks') && exitClicks >= parseInt(this.getAttribute('exit-clicks')))) {
+      this.dispatchEvent(new CustomEvent('exit-fullscreen', { bubbles: true }))
+    }
   }
 
   onEnterFullscreenClick() {

--- a/tangy-form-reducer.js
+++ b/tangy-form-reducer.js
@@ -297,7 +297,6 @@ const tangyFormReducer = function (state = initialState, action) {
       })
       return newState
 
-    // check state.form.exitClicks for exitClicks value
     case 'ENTER_FULLSCREEN':
       return {
         ...state,

--- a/tangy-form-reducer.js
+++ b/tangy-form-reducer.js
@@ -297,12 +297,14 @@ const tangyFormReducer = function (state = initialState, action) {
       })
       return newState
 
+    // check state.form.exitClicks for exitClicks value
     case 'ENTER_FULLSCREEN':
       return {
         ...state,
         fullscreenEnabled: true,
+        exitClicks:state.form.exitClicks,
         items: state.items.map(item => {
-          return { ...item, fullscreenEnabled: true}
+          return { ...item, fullscreenEnabled: true, exitClicks: state.form.exitClicks}
         })
       }
 

--- a/tangy-form.js
+++ b/tangy-form.js
@@ -339,6 +339,10 @@ export class TangyForm extends PolymerElement {
         type: Boolean,
         value: false,
         reflectToAttribute: true
+      },
+      fullScreenGranted: {
+        type: Boolean,
+        value: false,
       }
     }
   }
@@ -550,7 +554,7 @@ export class TangyForm extends PolymerElement {
       this.dispatchEvent(new CustomEvent('ALL_ITEMS_CLOSED'))
     }
 
-    if (state.form.fullscreen) {
+    if (state.form && state.form.fullscreen) {
       if (!this.previousState.fullscreenEnabled && state.fullscreenEnabled) {
         this.enableFullscreen()
       }
@@ -642,15 +646,24 @@ export class TangyForm extends PolymerElement {
   }
 
   enableFullscreen() {
-    if(this.requestFullscreen) {
-      this.requestFullscreen();
-    } else if(this.mozRequestFullScreen) {
-      this.mozRequestFullScreen();
-    } else if(this.webkitRequestFullscreen) {
-      this.webkitRequestFullscreen();
-    } else if(this.msRequestFullscreen) {
-      this.msRequestFullscreen();
-    }
+      if(this.requestFullscreen) {
+        this.requestFullscreen()
+            .then(message => {
+              this.fullScreenGranted = true;
+            })
+            .catch(err => {
+              console.log(`Error attempting to enable full-screen mode: ${err.message} (${err.name})`);
+              this.fullScreenGranted = false;
+              this.dispatchEvent(new CustomEvent('fullscreen-rejected'))
+            });
+      } else if(this.mozRequestFullScreen) {
+        this.mozRequestFullScreen();
+      } else if(this.webkitRequestFullscreen) {
+        this.webkitRequestFullscreen();
+      } else if(this.msRequestFullscreen) {
+        this.msRequestFullscreen();
+      }
+
   }
 
 }

--- a/tangy-form.js
+++ b/tangy-form.js
@@ -343,6 +343,11 @@ export class TangyForm extends PolymerElement {
       fullScreenGranted: {
         type: Boolean,
         value: false,
+      },
+      exitClicks: {
+        type: Number,
+        value: undefined,
+        reflectToAttribute: true
       }
     }
   }

--- a/test/tangy-eftouch_test.html
+++ b/test/tangy-eftouch_test.html
@@ -439,7 +439,6 @@
           const element = fixture('EFTouchTransitionSoundFixture')
           let eventDidFire = false
           element.addEventListener('manual-next', () => {
-            debugger;
             eventDidFire = true
             assert.equal(element.transitionSoundTriggered, true)
           })

--- a/test/tangy-form_test.html
+++ b/test/tangy-form_test.html
@@ -767,9 +767,6 @@
 
         test('should try to launch in fullscreen', function() {
           let element = fixture('HelloWorldWithFullScreenFixture')
-          // element.newResponse()
-          // element.querySelector('#item1').shadowRoot.querySelector('dom-if').render()
-          // assert.equal(element.querySelector('#item1').$.card.querySelector('#enable-fullscreen'), true)
           const fullscreenEl = element.querySelector('#item1').$.card.querySelector('#enable-fullscreen')
           fullscreenEl.click()
           const  isFullScreenEnabled = element.querySelector('#item1').fullscreenEnabled
@@ -784,7 +781,6 @@
             assert.equal(fullScreenGranted, false)
           })
         })
-
       });
 
       window.stub = {

--- a/test/tangy-form_test.html
+++ b/test/tangy-form_test.html
@@ -767,6 +767,7 @@
 
         test('should try to launch in fullscreen', function() {
           let element = fixture('HelloWorldWithFullScreenFixture')
+          element.newResponse()
           const fullscreenEl = element.querySelector('#item1').$.card.querySelector('#enable-fullscreen')
           fullscreenEl.click()
           const  isFullScreenEnabled = element.querySelector('#item1').fullscreenEnabled

--- a/test/tangy-form_test.html
+++ b/test/tangy-form_test.html
@@ -198,6 +198,15 @@
       </template>
     </test-fixture>
 
+    <test-fixture id="HelloWorldWithFullScreenFixture">
+      <template>
+        <tangy-form id="field-demo" title="Field Demo" on-change="" fullscreen="true">
+          <tangy-form-item id="item1">
+            <tangy-input name="input1"></tangy-input>
+          </tangy-form-item>
+        </tangy-form>
+      </template>
+    </test-fixture>
     
     <script type="module">
       import * as Polymer from '../node_modules/@polymer/polymer/polymer-legacy.js'
@@ -217,7 +226,6 @@
       })
 
       suite('tangy-form', () => {
-
 
         test('hello world without errors', () => {
           const element = fixture('HelloWorldFixture');
@@ -756,11 +764,28 @@
           assert.equal(element.querySelector('[open=""]').id, 'item-2')
           assert.equal(element.querySelectorAll('[open=""]').length, 1)
         })
-        test('should be fullscreen') 
-        test('should disable fullscreen after submit')
+
+        test('should try to launch in fullscreen', function() {
+          let element = fixture('HelloWorldWithFullScreenFixture')
+          // element.newResponse()
+          // element.querySelector('#item1').shadowRoot.querySelector('dom-if').render()
+          // assert.equal(element.querySelector('#item1').$.card.querySelector('#enable-fullscreen'), true)
+          const fullscreenEl = element.querySelector('#item1').$.card.querySelector('#enable-fullscreen')
+          fullscreenEl.click()
+          const  isFullScreenEnabled = element.querySelector('#item1').fullscreenEnabled
+          // we cannot test fullScreen - it is not permitted in Chrome.
+          // "Failed to execute 'requestFullscreen' on 'Element': API can only be initiated by a user gesture."
+          console.log("isFullScreenEnabled: " + isFullScreenEnabled)
+          // but we can check if fullScreenGranted
+          // must wait til event is fired.
+          element.addEventListener('fullscreen-rejected', () => {
+            const fullScreenGranted = element.fullScreenGranted;
+            console.log("fullScreenGranted: " + fullScreenGranted)
+            assert.equal(fullScreenGranted, false)
+          })
+        })
+
       });
-
-
 
       window.stub = {
        responseWithTangyCard: {"_id":"94897a00-ea84-46ba-b046-21505dd1a1e9","collection":"TangyFormResponse","form":{"title":"My Form","complete":true,"linearMode":false,"hideClosedItems":false,"hideCompleteFab":false,"tabIndex":1,"showResponse":true,"showSummary":false,"hasSummary":false,"onSubmit":"","id":"tangy-cards-demo","tagName":"TANGY-FORM"},"items":[{"id":"item1","title":"People","summary":false,"hideButtons":false,"hideBackButton":true,"rightToLeft":false,"hideNextButton":true,"showCompleteButton":true,"inputs":[{"name":"person","value":[{"name":"c911e052-bea0-4ee9-b3b0-e93023a025c0","value":[{"name":"first_name","private":false,"label":"First name","type":"","errorMessage":"","required":false,"disabled":false,"hidden":false,"invalid":false,"incomplete":true,"value":"foo","allowedPattern":"","min":"","max":"","tagName":"TANGY-INPUT"},{"name":"last_name","private":false,"label":"Last name","type":"","errorMessage":"","required":false,"disabled":false,"hidden":false,"invalid":false,"incomplete":true,"value":"","allowedPattern":"","min":"","max":"","tagName":"TANGY-INPUT"}],"label":"","disabled":false,"invalid":false,"incomplete":true,"hidden":false},{"name":"9d27d598-a811-4e80-b04d-d18523303c12","value":[{"name":"first_name","private":false,"label":"First name","type":"","errorMessage":"","required":false,"disabled":false,"hidden":false,"invalid":false,"incomplete":true,"value":"","allowedPattern":"","min":"","max":"","tagName":"TANGY-INPUT"},{"name":"last_name","private":false,"label":"Last name","type":"","errorMessage":"","required":false,"disabled":false,"hidden":false,"invalid":false,"incomplete":true,"value":"","allowedPattern":"","min":"","max":"","tagName":"TANGY-INPUT"}],"label":"","disabled":false,"invalid":false,"incomplete":true,"hidden":false},{"name":"fd1a64c6-f52a-4480-9a2d-c4792ca2bb39","value":[{"name":"first_name","private":false,"label":"First name","type":"","errorMessage":"","required":false,"disabled":false,"hidden":false,"invalid":false,"incomplete":true,"value":"","allowedPattern":"","min":"","max":"","tagName":"TANGY-INPUT"},{"name":"last_name","private":false,"label":"Last name","type":"","errorMessage":"","required":false,"disabled":false,"hidden":false,"invalid":false,"incomplete":true,"value":"","allowedPattern":"","min":"","max":"","tagName":"TANGY-INPUT"}],"label":"","disabled":false,"invalid":false,"incomplete":true,"hidden":false}],"label":"","disabled":true,"invalid":false,"incomplete":true,"hidden":false}],"open":false,"incomplete":false,"disabled":false,"hidden":false,"locked":true,"tagName":"TANGY-FORM-ITEM"}],"inputs":[],"complete":true,"focusIndex":0,"nextFocusIndex":1,"previousFocusIndex":-1,"startDatetime":"10/5/2018, 12:45:43 PM","startUnixtime":1538757943292,"uploadDatetime":""}


### PR DESCRIPTION
This enables admin to set the number of taps before fullscreen mode can be dismissed. 

Usage:
```
<tangy-form-item id="intro" title="Intro"  exit-clicks="3">
```

