### PR TITLE
#1591 fix text overlapping

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 # CHANGELOG
 
+## v4.3.0
+
 ## v4.2.0
 - Added the exit-clicks attribute to tangy-form and tangy-form-item, which is for the number of times a user must click the exit fullscreen button before that mode is deactivated. 
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # CHANGELOG
 
 ## v4.3.0
+- Fix data collector reviews completed fullscreen form [#75](https://github.com/Tangerine-Community/tangy-form/pull/75)
 
 ## v4.2.0
 - Added the exit-clicks attribute to tangy-form and tangy-form-item, which is for the number of times a user must click the exit fullscreen button before that mode is deactivated. 

--- a/input/tangy-eftouch.js
+++ b/input/tangy-eftouch.js
@@ -175,7 +175,8 @@ export class TangyEftouch extends PolymerElement {
         this.transition()
       }, this.timeLimit)
     }
-    //this.fitIt()
+    this.fitItInterval = setInterval(this.fitIt.bind(this), Math.floor(1000/30))
+    this.fitIt()
   }
 
   disconnectedCallback () {
@@ -199,9 +200,6 @@ export class TangyEftouch extends PolymerElement {
     this.shadowRoot.innerHTML = `
       <style>
         :host {
-          position: fixed;
-          top: ${this.fromTopOfScreen}px;
-          left: 0px;
           width: 100%
         }
         :host tangy-radio-buttons {
@@ -277,10 +275,12 @@ export class TangyEftouch extends PolymerElement {
           </div>
         ` : ''}
       </div>
-      <div id="options-box">
+      <div id="options-box" style="opacity: 0">
       ${options.map(option => `
         <span 
           id="cell"
+          ef-width="${option.getAttribute('width')}"
+          ef-height="${option.getAttribute('height')}"
           ${option.hasAttribute('correct') ? 'correct' : ''}
           ${
             this.hasAttribute('multi-select')
@@ -389,20 +389,21 @@ export class TangyEftouch extends PolymerElement {
   }
 
   fitIt() {
-    this.fitItInterval = setInterval(() => {
-      // Protect against not having a shadow yet.
-      if (!this.radioButtonsEl) return
-      // Protect against when the element has not yet grown up.
-      if (this.radioButtonsEl.offsetHeight / this.radioButtonsEl.offsetWidth === NaN) return 
-      // Protect from doing this over and over.
-      if (this.hasAttribute('fullscreen-size-complete')) return
-      const topMargin = 100
-      const targetHeight = window.visualViewport.height - topMargin
-      const actualHeight = this.radioButtonsEl.offsetHeight
-      let targetWidth = Math.floor(this.radioButtonsEl.offsetHeight / this.radioButtonsEl.offsetWidth * targetHeight)
-      this.radioButtonsEl.style.width = `${targetWidth}px`
-      this.setAttribute('fullscreen-size-complete', '')
-    }, 100)
+    const optionsBoxEl = this.shadowRoot.querySelector('#options-box')
+    const messageBoxHeight = 60
+    const totalHeight = window.innerHeight - optionsBoxEl.offsetTop - messageBoxHeight
+    const cellBorder = 10
+    const totalWidth = optionsBoxEl.clientWidth
+    if (totalWidth > 0) optionsBoxEl.style.opacity = '1'
+    // Because browsers don't render so good. Need extra room so it doesn't throw in an eager line break.
+    const extraSideRoom = 10
+    optionsBoxEl.querySelectorAll('#cell').forEach(cellEl => {
+      cellEl.setAttribute('style', `
+        display: inline-block;
+        width:${Math.floor((cellEl.getAttribute('ef-width')/100)*totalWidth) - cellBorder - extraSideRoom}px;
+        height:${Math.floor((cellEl.getAttribute('ef-height')/100)*(totalHeight)) - cellBorder}px;
+      `)
+    })
   }
 
   validate() {

--- a/input/tangy-eftouch.js
+++ b/input/tangy-eftouch.js
@@ -362,30 +362,30 @@ export class TangyEftouch extends PolymerElement {
       this.render()
     }
     this.dispatchEvent(new Event('change'))
-    if (this.canTransition) this.startTransition()
+    if (this.canTransition) this.transition()
   }
 
   get canTransition() {
     return this.validate() && (this.transitionMessage || this.autoProgress || this.timeLimit)
   }
 
-  startTransition() {
+  transition() {
+    if (this.hasAttribute('transition-triggered')) return
     this.setAttribute('transition-triggered', true)
-    if (this.transitionDelay > 0) {
+    const finishTransition = () => {
+      if (this.transitionSound) {
+        new Audio(this.transitionSound).play()
+        this.transitionSoundTriggered = true
+      }
+      if (this.autoProgress) this.dispatchEvent(new CustomEvent('next'))
+    }
+   if (this.transitionDelay > 0) {
       setTimeout(() => {
-        this.transition()
+        finishTransition()
       }, this.transitionDelay)
     } else {
-      this.transition()
+      finishTransition()
     }
-  }
-
-  transition() {
-    if (this.transitionSound) {
-      new Audio(this.transitionSound).play()
-      this.transitionSoundTriggered = true
-    }
-    if (this.autoProgress) this.dispatchEvent(new CustomEvent('next'))
   }
 
   fitIt() {

--- a/tangy-form-reducer.js
+++ b/tangy-form-reducer.js
@@ -52,8 +52,9 @@ const tangyFormReducer = function (state = initialState, action) {
         form: Object.assign({}, state.form, {
           complete: true,
           linearMode: false,
+          hideClosedItems: false,
           fullscreen: false,
-          hideClosedItems: false
+          fullscreenEnabled: false
         }),
         items: state.items.map(item => {
           let props = {}
@@ -73,6 +74,7 @@ const tangyFormReducer = function (state = initialState, action) {
           props.hideBackButton = true
           props.hideNextButton = true
           props.fullscreen = false
+          props.fullscreenEnabled = false
           props.inputs = item.inputs.map(input => {
             if (input.tagName === 'TANGY-TIMED') {
               return Object.assign({}, input, {disabled: true, mode: 'TANGY_TIMED_MODE_DISABLED'})
@@ -300,8 +302,11 @@ const tangyFormReducer = function (state = initialState, action) {
     case 'ENTER_FULLSCREEN':
       return {
         ...state,
-        fullscreenEnabled: true,
-        exitClicks:state.form.exitClicks,
+        form: {
+          ...state.form,
+          fullscreenEnabled: true,
+          exitClicks: state.form.exitClicks
+        },
         items: state.items.map(item => {
           return { ...item, fullscreenEnabled: true, exitClicks: state.form.exitClicks}
         })
@@ -310,7 +315,10 @@ const tangyFormReducer = function (state = initialState, action) {
     case 'EXIT_FULLSCREEN':
       return {
         ...state,
-        fullscreenEnabled: false,
+        form: {
+          ...state.form,
+          fullscreenEnabled: false,
+        },
         items: state.items.map(item => {
           return { ...item, fullscreenEnabled: false}
         })

--- a/tangy-form.js
+++ b/tangy-form.js
@@ -292,7 +292,8 @@ export class TangyForm extends PolymerElement {
     return {
       fullscreen: {
         type: Boolean,
-        value: false
+        value: false,
+        reflectToAttribute: true
       },
       title: {
         type: String,
@@ -368,9 +369,6 @@ export class TangyForm extends PolymerElement {
 
   ready() {
     super.ready()
-    if (this.fullscreen) {
-      this.addEventListener('click', this.enableFullscreen, true)
-    }
     // Pass events of items to the reducer.
     this.hasLazyItems = false
     this.querySelectorAll('tangy-form-item').forEach((item) => {
@@ -560,12 +558,14 @@ export class TangyForm extends PolymerElement {
     }
 
     if (state.form && state.form.fullscreen) {
-      if (!this.previousState.fullscreenEnabled && state.fullscreenEnabled) {
+      if (!this.previousState.form.fullscreenEnabled && state.form.fullscreenEnabled) {
         this.enableFullscreen()
       }
-      else if (this.previousState.fullscreenEnabled && !state.fullscreenEnabled) {
+      else if (this.previousState.form.fullscreenEnabled && !state.form.fullscreenEnabled) {
         this.disableFullscreen()
       }
+    } else if (this.previousState.form.fullscreen && !state.form.fullscreen) {
+      this.disableFullscreen()
     }
 
     // Stash as previous state.

--- a/test/tangy-eftouch_test.html
+++ b/test/tangy-eftouch_test.html
@@ -415,6 +415,23 @@
           assert.equal(eventDidFire, false)
         });
 
+        test('should auto-progress from selection not also from time limit', (done) => { 
+          const element = fixture('EFTouchTimeLimitAutoProgressFixture')
+          let eventDidFire = false
+          let eventDidFireTwice = false
+          element.addEventListener('next', () => {
+            eventDidFireTwice = eventDidFire === true ? true : false
+            eventDidFire = true
+          })
+          setTimeout(() => {
+            assert.equal(eventDidFire, true)
+            assert.equal(eventDidFireTwice, false)
+            done()
+          }, 105)
+          assert.equal(eventDidFire, false)
+          element.shadowRoot.querySelector('img').click()
+        });
+
         // TODO: new attribute: auto-progress-at-timelimit
         test('should transition automatically at time-limit but not on user input');
 


### PR DESCRIPTION
This fixes https://github.com/Tangerine-Community/Tangerine/issues/1591 and https://github.com/Tangerine-Community/Tangerine/issues/1587

This takes an approach of calculating a box of maximum available space given content above and height of window. That fixes the overlapping text given arbitrary amount of content above eftouch element. This also takes a more careful approach at approaching width calculations, and compensates for browser's eager line breaking.