### PR TITLE
#1597 add number of selections before go next (example: `go-next-after-selection=2`)

### DIFF
--- a/input/tangy-eftouch.js
+++ b/input/tangy-eftouch.js
@@ -51,11 +51,6 @@ export class TangyEftouch extends PolymerElement {
         value: false,
         reflectToAttribute: true
       },
-      goNextOnSelection: {
-        type: Boolean,
-        value: false,
-        reflectToAttribute: true
-      },
       correct: {
         type: Boolean,
         value: false,
@@ -395,7 +390,9 @@ export class TangyEftouch extends PolymerElement {
     }
     this.render()
     this.dispatchEvent(new Event('change'))
-    if (this.hasAttribute('go-next-on-selection') && this.validate()) this.transition(true)
+    if (this.hasAttribute('go-next-on-selection') && this.value && this.value.selection && this.value.selection.length >= parseInt(this.getAttribute('go-next-on-selection')) && this.validate()) {
+      this.transition(true)
+    }
   }
 
   transition(goNext = false) {

--- a/test/tangy-eftouch_test.html
+++ b/test/tangy-eftouch_test.html
@@ -67,7 +67,7 @@
 
     <test-fixture id="EFTouchAutoProgressFixture">
       <template>
-        <tangy-eftouch go-next-on-selection value="fruit_selection" label="What is your favorite fruit?">
+        <tangy-eftouch go-next-on-selection=1 label="What is your favorite fruit?">
           <option value="orange" src="assets/images/cat.png"></option>
           <option value="banana" src="assets/images/cat.png"></option>
           <option value="tangerine" src="assets/images/cat.png"></option>
@@ -77,6 +77,20 @@
         </tangy-eftouch>
       </template>
     </test-fixture>
+
+    <test-fixture id="EFTouchGoNextAfter2SelectionsFixture">
+      <template>
+        <tangy-eftouch multi-select go-next-on-selection="2" label="What is your favorite fruit?">
+          <option value="orange" src="assets/images/cat.png"></option>
+          <option value="banana" src="assets/images/cat.png"></option>
+          <option value="tangerine" src="assets/images/cat.png"></option>
+          <option value="cantalope" src="assets/images/cat.png"></option>
+          <option value="cherry" src="assets/images/cat.png"></option>
+          <option value="kiwi" src="assets/images/cat.png"></option>
+        </tangy-eftouch>
+      </template>
+    </test-fixture>
+
 
     <test-fixture id="EFTouchImagesFixture">
       <template>
@@ -98,7 +112,7 @@
           transition-sound="assets/sounds/swish.mp3"
           transition-delay=100 
           transition-message="You are being transerred to the next item."
-          go-next-on-selection
+          go-next-on-selection=1
           name="fruit_selection"
           label="What is your favorite fruit?"
           >
@@ -339,6 +353,18 @@
             eventDidFire = true
           })
           element.shadowRoot.querySelector('img').click()
+          assert.equal(eventDidFire, true)
+        });
+
+        test('should go next after 2 selections', () => {
+          const element = fixture('EFTouchGoNextAfter2SelectionsFixture');
+          let eventDidFire = false
+          element.addEventListener('next', _ => {
+            eventDidFire = true
+          })
+          element.shadowRoot.querySelector('img').click()
+          assert.equal(eventDidFire, false)
+          element.shadowRoot.querySelectorAll('img')[1].click()
           assert.equal(eventDidFire, true)
         });
 


### PR DESCRIPTION
Related to https://github.com/Tangerine-Community/Tangerine/issues/1597