### PR TITLE
Fix needless TangyForm.on-change events from firing when they don't need to

### DIFF
--- a/tangy-form-item.js
+++ b/tangy-form-item.js
@@ -543,7 +543,6 @@ export class TangyFormItem extends PolymerElement {
       .forEach(input => {
         input.addEventListener('next', () => this.next())
         input.addEventListener('change', _ => {
-          _.stopImmediatePropagation()
           this.fireHook('on-change', _)
         })
       })

--- a/tangy-form-item.js
+++ b/tangy-form-item.js
@@ -543,7 +543,7 @@ export class TangyFormItem extends PolymerElement {
       .forEach(input => {
         input.addEventListener('next', () => this.next())
         input.addEventListener('change', _ => {
-          this.dispatchEvent(new Event('change', {details: _.target}))
+          _.stopImmediatePropagation()
           this.fireHook('on-change', _)
         })
       })

--- a/tangy-form.js
+++ b/tangy-form.js
@@ -489,8 +489,8 @@ export class TangyForm extends PolymerElement {
       type: 'ITEM_SAVE',
       item: event.target.getProps()
     })
-    this.focusOnNextItem()
     this.fireHook('on-change')
+    this.focusOnNextItem()
   }
 
   onItemBack(event) {
@@ -498,8 +498,8 @@ export class TangyForm extends PolymerElement {
       type: 'ITEM_SAVE',
       item: event.target.getProps()
     })
-    this.focusOnPreviousItem()
     this.fireHook('on-change')
+    this.focusOnPreviousItem()
   }
 
   onItemOpened(event) {
@@ -581,8 +581,6 @@ export class TangyForm extends PolymerElement {
 
     // Stash as previous state.
     this.previousState = Object.assign({}, state)
-
-    if (!this.complete) this.fireHook('on-change')
 
   }
 

--- a/tangy-form.js
+++ b/tangy-form.js
@@ -482,7 +482,6 @@ export class TangyForm extends PolymerElement {
       type: 'ITEM_CHANGE',
       itemId: event.target.id
     })
-    this.fireHook('on-change')
   }
 
   onItemNext(event) {


### PR DESCRIPTION
Right now, with every key stroke in something like `<tangy-input>` the `<tangy-form on-change="...">` on-change logic is running TWICE. The first time is because TangyForm dispatches a `change` event when one of it's inputs fires a change event. This has been the case for a long time. The second change event is caused by the input's change event bubbling up through to the tangy-form-item. This is new since we moved the land of inputs from the Item's shadowRoot to a slot. 

The problem is this may cause performance issues when typing. The sad thing is, the result of every key stroke does not make a difference to the TangyForm.on-change logic because that data doesn't bubble up until late with an `ITEM_SAVE` action. So the logic running over and over again for no reason.  

This PR prevents a duplicate change event from firing, makes sure that TangyFormItem does not fire a duplicate change event (TangyForm still needs to hear a change event to know the item is "dirty"), and makes sure that TangyForm only fires it's on-change hook after and item is saved but before the focus of which item is viewed changes.
