### PR TITLE
Capture item at n seconds

### DIFF
--- a/demo/tangy-timed.html
+++ b/demo/tangy-timed.html
@@ -1,0 +1,118 @@
+<!doctype html>
+<html lang="en">
+
+<head>
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width, minimum-scale=1, initial-scale=1, user-scalable=yes">
+
+    <title>tangy-form demo</title>
+
+    <script src="../node_modules/@webcomponents/webcomponentsjs/webcomponents-loader.js"></script>
+    <script src="../node_modules/devtools-detect/index.js"></script>
+    <script src="../node_modules/redux/dist/redux.min.js"></script>
+
+    <script type="module">
+        import '@polymer/iron-demo-helpers/demo-pages-shared-styles';
+        import '@polymer/iron-demo-helpers/demo-snippet';
+    </script>
+    <custom-style>
+        <style>
+            html {
+                --document-background-color: #FAFAFA;
+                --primary-color-dark: #3c5b8d;
+                --primary-text-color: var(--light-theme-text-color);
+                --primary-color: #3c5b8d;
+                --accent-color: #f26f10;
+                --accent-text-color: #FFF;
+                --error-color: var(--paper-red-500);
+                --disabled-color: #BBB;
+            }
+
+            h1,
+            h2,
+            h3,
+            h4,
+            h5 {
+                @apply --paper-font-common-base;
+                color: var(--primary-text-color);
+                margin: 25px 0px 5px 15px;
+            }
+        </style>
+    </custom-style>
+    <script type="module" src="../tangy-form.js"></script>
+    <script type="module" src="../input/tangy-acasi.js"></script>
+    <script type="module" src="../input/tangy-box.js"></script>
+    <script type="module" src="../input/tangy-checkbox.js"></script>
+    <script type="module" src="../input/tangy-checkboxes.js"></script>
+    <script type="module" src="../input/tangy-checkboxes-dynamic.js"></script>
+    <script type="module" src="../input/tangy-eftouch.js"></script>
+    <script type="module" src="../input/tangy-gps.js"></script>
+    <script type="module" src="../input/tangy-input.js"></script>
+    <script type="module" src="../input/tangy-location.js"></script>
+    <script type="module" src="../input/tangy-radio-button.js"></script>
+    <script type="module" src="../input/tangy-radio-buttons.js"></script>
+    <script type="module" src="../input/tangy-select.js"></script>
+    <script type="module" src="../input/tangy-timed.js"></script>
+    <script type="module" src="../input/tangy-untimed-grid.js"></script>
+    <script type="module" src="../input/tangy-toggle-button.js"></script>
+    <script type="module" src="../input/tangy-photo-capture.js"></script>
+    <script type="module" src="../input/tangy-qr.js"></script>
+    <script type="module" src="../input/tangy-consent.js"></script>
+
+    <custom-style>
+        <style is="custom-style" include="demo-pages-shared-styles">
+        </style>
+    </custom-style>
+</head>
+
+<body>
+    <div class="vertical-section-container centered">
+        <h3>tangy-timed-grid</h3>
+        <demo-snippet>
+            <template>
+                <tangy-form id="tangy-timed-grid-form" title="My Form">
+                    <tangy-form-item id="tangy-timed-grid-item" title="Tangy Timed Grid">
+                        <tangy-timed required columns="3" name="tangy-timed-grid" auto-stop="2" capture-item-at="5"
+                            duration="15">
+                            <option value="class1_term2-d">1</option>
+                            <option value="class1_term2-1">Jumatatu,</option>
+                            <option value="class1_term2-2">wezi</option>
+                            <option value="class1_term2-3">walikuja</option>
+                            <option value="class1_term2-4">kijijini.</option>
+                            <option value="class1_term2-5">Watu</option>
+                            <option value="class1_term2-6">wakapiga</option>
+                            <option value="class1_term2-7">mayowe.</option>
+                            <option value="class1_term2-8">“Tunataka</option>
+                            <option value="class1_term2-9">dhahabu!”</option>
+                            <option value="class1_term2-10">wezi</option>
+                            <option value="class1_term2-11">wakasema.</option>
+                            <option value="class1_term2-12">Watu</option>
+                            <option value="class1_term2-13">walipatwa</option>
+                            <option value="class1_term2-14">na</option>
+                            <option value="class1_term2-15">wasiwasi.</option>
+                            <option value="class1_term2-16">Watu</option>
+                            <option value="class1_term2-17">wakasema,</option>
+                            <option value="class1_term2-18">“Hatuna</option>
+                            <option value="class1_term2-19">chochote</option>
+                            <option value="class1_term2-20">cha</option>
+                            <option value="class1_term2-21">thamani.”</option>
+                            <option value="class1_term2-22">Polisi</option>
+                            <option value="class1_term2-23">walifika</option>
+                            <option value="class1_term2-24">hapo.</option>
+                            <option value="class1_term2-25">Waliwashika</option>
+                            <option value="class1_term2-26">wezi</option>
+                            <option value="class1_term2-27">na</option>
+                            <option value="class1_term2-28">kuwatia</option>
+                            <option value="class1_term2-29">pingu.</option>
+                            <option value="class1_term2-30">Wezi</option>
+                            <option value="class1_term2-31">walipelekwa</option>
+                            <option value="class1_term2-32">gerezani.</option>
+                        </tangy-timed>
+                    </tangy-form-item>
+                </tangy-form>
+            </template>
+        </demo-snippet>
+    </div>
+</body>
+
+</html>

--- a/input/tangy-timed.js
+++ b/input/tangy-timed.js
@@ -164,6 +164,20 @@ class TangyTimed extends PolymerElement {
       #info {
         padding-top: 70px;
       }
+
+      .blink-green-bg{
+          animation-name: animation;
+          animation-duration: 0.2s;
+          animation-timing-function: steps(5);
+          animation-iteration-count: 3;    
+          animation-play-state: running;
+      }
+      @keyframes animation {
+        0.0%     {background-color:var(--document-background-color);}
+        50.0%  {background-color:green;}
+        100.0%  {background-color:var(--document-background-color);}
+    }
+      
     </style>
     <label class="hint-text">[[hintText]]</label>
     <div id="container">
@@ -496,6 +510,7 @@ class TangyTimed extends PolymerElement {
             }
           }, 200);
         } else {
+          clearInterval(this.timer2)
           this.value = this.value.map(buttonState => {
             return Object.assign({}, buttonState, {
               highlighted: false,
@@ -560,10 +575,10 @@ class TangyTimed extends PolymerElement {
 
       case TANGY_TIMED_CAPTURE_ITEM_AT:
         this.statusMessage = t(`Tap the item at ${this.captureItemAt} seconds`)
-        this.style.background = 'green'
-        setTimeout(() => this.style.background = 'white', 200)
-        setTimeout(() => this.style.background = 'green', 400)
-        setTimeout(() => this.style.background = 'white', 600)
+        this.shadowRoot.querySelector('#container').classList.add('blink-green-bg')
+        setTimeout(() => {
+          this.shadowRoot.querySelector('#container').classList.remove('blink-green-bg')
+        }, 4000);
         break
 
     }
@@ -585,6 +600,7 @@ class TangyTimed extends PolymerElement {
     }
   }
   stopGrid() {
+
     clearInterval(this.timer)
     clearInterval(this.timer2)
     this.isItemCaptured = false
@@ -662,9 +678,12 @@ class TangyTimed extends PolymerElement {
         this.dispatchEvent(new Event('change'))
         break
       case TANGY_TIMED_CAPTURE_ITEM_AT:
-        newValue = this.value.map(buttonState => {
+
+        newValue = this.value.map((buttonState, index) => {
           if (buttonState.name === event.target.name) {
             this.isItemCaptured = true
+            this.gridVarItemAtTime = index + 1
+            this.gridVarTimeIntermediateCaptured = this.duration - this.timeRemaining
             return {
               ...buttonState, captured: true,
               disabled: false
@@ -697,6 +716,7 @@ class TangyTimed extends PolymerElement {
     this.endTime = Date.now()
     clearInterval(this.timer);
     clearInterval(this.timer2);
+    this.isItemCaptured = false;
     // We have to check for typeof string because the event handler on the stop button puts an integer in the second param for some reason.
     // If it's a string, then we know it's an ID of something which should actually be lastItemAttempted.
     if (typeof lastItemAttempted === 'string') {

--- a/input/tangy-timed.js
+++ b/input/tangy-timed.js
@@ -489,7 +489,6 @@ class TangyTimed extends PolymerElement {
         if (this.isItemCaptured) {
           clearInterval(this.timer)
           this.timer2 = setInterval(() => {
-            this;
             let timeSpent = Math.floor((Date.now() - this.startTime) / 1000)
             this.timeRemaining = this.duration - timeSpent
             if (this.timeRemaining <= 0) {

--- a/input/tangy-toggle-button.js
+++ b/input/tangy-toggle-button.js
@@ -38,6 +38,9 @@ class TangyToggleButton extends PolymerElement {
       :host([highlighted]) {
         border-color: var(--accent-color);
       }
+      :host([captured]){
+        border-color: var(--error-color);
+      }
       :host([required]:not([disabled])) label::before  { 
         content: "*"; 
         color: red; 
@@ -91,6 +94,11 @@ class TangyToggleButton extends PolymerElement {
         reflectToAttribute: true
       },
       highlighted: {
+        type: Boolean,
+        value: false,
+        reflectToAttribute: true
+      },
+      captured: {
         type: Boolean,
         value: false,
         reflectToAttribute: true


### PR DESCRIPTION
## Description

---

As an editor I would like an option that will enable data collectors to capture the item read at a specific point in time( `n seconds`)
When `n seconds` have elapsed, the user is prompted to mark the item read at the time mark. 
The index of the item selected and the specific time at which it is marked are captured as `gridVarItemAtTime` and `gridVarTimeIntermediateCaptured` respectively

- Fixes #IssueNumber

* Closes Tangerine-Community/Tangerine#1586
* Needs Tangerine-Community/Tangerine#1674 for the `csv` generation bit.
## Type of Change

- New feature (non-breaking change which adds functionality)
- This change requires a documentation update as follows.
   - One new attribute is added, `capture-item-at` which is of type `Number` and is measure in `seconds`. 
   - `gridVarItemAtTime` and `gridVarTimeIntermediateCaptured` are also class scoped variables or more precisely `class attributes`.

## Proposed Solution

---

* Add the attribute `capture-item-at`. This is by exposing the property `captureItemAt` in `Polymer`. 
* Use css keyframes to animate the background when the timer reaches `n seconds` to simulate the screen flashing.
* We need to add new properties on the `server` in the `csv` generation module in order to have `gridVarItemAtTime` and `gridVarTimeIntermediateCaptured` available in  the `csv`.
* For the `csv` portion  to have column headers for `gridVarItemAtTime` and `gridVarTimeIntermediateCaptured` in the generated `csv` we need to add some processing logic withe the two class attributes added to the server file.

## Limitations and Trade-offs

* The values of the background color is hardcoded to green, and at times to red.
* 

## Screenshots/Videos

---
* https://recordit.co/8uQZbsyAiL

## Tests

---

* No written tests

