### PR TITLE
Check if captureItemAt is defined

### DIFF
--- a/input/tangy-timed.js
+++ b/input/tangy-timed.js
@@ -276,7 +276,7 @@ class TangyTimed extends PolymerElement {
       },
       captureItemAt: {
         type: Number,
-        value: 5,
+        value: undefined,
         reflectToAttribute: true
       },
       // Number of columns to show items, calibrated for a Nexus 7 in landscape mode.
@@ -706,9 +706,11 @@ class TangyTimed extends PolymerElement {
   onStartClick() {
     this.reset()
     this.mode = TANGY_TIMED_MODE_RUN
-    setTimeout(() => {
-      this.mode = TANGY_TIMED_CAPTURE_ITEM_AT
-    }, this.captureItemAt * 1000);
+    if (this.captureItemAt) {
+      setTimeout(() => {
+        this.mode = TANGY_TIMED_CAPTURE_ITEM_AT
+      }, this.captureItemAt * 1000);
+    }
 
   }
 


### PR DESCRIPTION
## Description

---

When `capture-item-at` is not defined, the trigger to capture item is fired immediately. This is because JS coerced undefined to `0` and thus the callback fires immediately after `0 seconds`. What we want is that, when the attribute `capture-item-at` is not defined, the callback is never called nor registered.

- Enhances #95 

## Type of Change

- Bug fix (non-breaking change which fixes an issue)

## Proposed Solution

---

Check if the `capture-item-at` attribute is `undefined`. If it is, do not register the callback. Otherwise if defined, register the callback with the specified value of `capture-item-at`

