### PR TITLE
Add the property "value" when the row marker is clicked for each of the buttons

### DIFF
--- a/input/tangy-timed.js
+++ b/input/tangy-timed.js
@@ -629,6 +629,7 @@ class TangyTimed extends PolymerElement {
         this.shadowRoot.querySelectorAll('tr')[rowNumber].querySelectorAll('tangy-toggle-button')
           .forEach(tangyToggleButtonEl => {
             tangyToggleButtonEl.pressed = true
+            tangyToggleButtonEl.value = 'on'
           })
         let newValue = []
         this.shadowRoot


### PR DESCRIPTION
## Description

---
* When the `row-marker` is clicked so as to mark an entire line as incorrect, the buttons should highlighted and the `value` property set to `"on"`  and `pressed:true`. 
* Currently, only `pressed:true` is set, thus when the CSV is generated, the items marked as incorrect using the `row-marker` do not appear as such in the CSV
- Fixes Tangerine-Community/Tangerine/#1713

## Type of Change

[Please delete irrelevant options]

- Bug fix (non-breaking change which fixes an issue)

## Proposed Solution

---
* When the `row-marker` is clicked, set the property `value` to `"on"` for each of the buttons in the row.


## TODOS/enhancements

---
* We should write a transformer function that checks for items thats were marked using the row marker but whose `value` property was not set to `"on"` for existing records. This should probably run once to fix the data already stored in DBs.
