### PR TITLE
Add support for warnings and discrepancies

### DIFF
--- a/demo/all-inputs-flagged.html
+++ b/demo/all-inputs-flagged.html
@@ -1,0 +1,420 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width, minimum-scale=1, initial-scale=1, user-scalable=yes">
+
+    <title>Tangy Form Inputs Demo</title>
+
+    <script src="../node_modules/@webcomponents/webcomponentsjs/webcomponents-loader.js"></script>
+    <script src="../node_modules/devtools-detect/index.js"></script>
+    <script src="../node_modules/redux/dist/redux.min.js"></script>
+
+    <custom-style>
+      <style>
+        html {
+          --document-background-color: #FAFAFA;
+          --primary-color-dark: #3c5b8d;
+          --primary-text-color: var(--light-theme-text-color);
+          --primary-color: #3c5b8d;
+          /*--accent-color: #f26f10;*/
+          --accent-color: #3c5b8d;
+          --accent-text-color: #FFF;
+          --error-color: var(--paper-red-500);
+          --disabled-color: #BBB;
+          --tangy-element-border: 0;
+          /*--tangy-element-margin: 0;*/
+        }
+        h1, h2, h3, h4, h5, p{
+          @apply --paper-font-common-base;
+          color: var(--primary-text-color);
+          margin: 15px 0px 5px 15px;
+        }
+      </style>
+    </custom-style>
+    <script type="module" src="../tangy-form.js"></script>
+    <script type="module" src="../input/tangy-checkbox.js"></script>
+    <script type="module" src="../input/tangy-checkboxes.js"></script>
+    <script type="module" src="../input/tangy-consent.js"></script>
+    <script type="module" src="../input/tangy-gps.js"></script>
+    <script type="module" src="../input/tangy-input.js"></script>
+    <script type="module" src="../input/tangy-location.js"></script>
+    <script type="module" src="../input/tangy-partial-date.js"></script>
+    <script type="module" src="../input/tangy-photo-capture.js"></script>
+    <script type="module" src="../input/tangy-qr.js"></script>
+    <script type="module" src="../input/tangy-radio-button.js"></script>
+    <script type="module" src="../input/tangy-radio-buttons.js"></script>
+    <script type="module" src="../input/tangy-select.js"></script>
+  </head>
+  <body>
+    <h3>Inputs Demo</h3>
+    <tangy-form id="my-form" title="My Form">
+              
+        <tangy-form-item id="item1" title="Item 1">
+
+            <tangy-checkbox
+                name="checkbox" 
+                question-number="1." 
+                label="
+                    <t-lang en>English label.</t-lang>
+                    <t-lang fr>French label.</t-lang>
+                "
+                hint-text="
+                    <t-lang en>English hint-text.</t-lang>
+                    <t-lang fr>French hint-text.</t-lang>
+                "
+                error-text="
+                    <t-lang en>English error-text.</t-lang>
+                    <t-lang fr>French error-text.</t-lang>
+                "
+                discrepancy-text="Discrepancy text."
+                warn-text="Warn text."
+                has-warning
+                has-discrepancy
+                invalid
+                required>
+            </tangy-checkbox>
+            
+            <tangy-checkboxes
+                name="checkboxes" 
+                question-number="1." 
+                label="
+                    <t-lang en>English label.</t-lang>
+                    <t-lang fr>French label.</t-lang>
+                "
+                hint-text="
+                    <t-lang en>English hint-text.</t-lang>
+                    <t-lang fr>French hint-text.</t-lang>
+                "
+                error-text="
+                    <t-lang en>English error-text.</t-lang>
+                    <t-lang fr>French error-text.</t-lang>
+                "
+                discrepancy-text="Discrepancy text."
+                warn-text="Warn text."
+                has-warning
+                has-discrepancy
+                invalid
+                required>
+                <option 
+                    value="Z" 
+                    hint-text="
+                        <t-lang en>English hint-text.</t-lang>
+                        <t-lang fr>French hint-text.</t-lang>
+                    "
+                >
+                    <t-lang en>English label.</t-lang>
+                    <t-lang fr>French label.</t-lang>
+                </option>
+                <option value="A">A</option>
+                <option value="B">B</option>
+                <option value="C">C</option>
+                <option value="D">D</option>
+            </tangy-checkboxes>
+
+            <tangy-consent
+                name="consent" 
+                question-number="1." 
+                prompt="
+                    <t-lang en>English prompt.</t-lang>
+                    <t-lang fr>French prompt.</t-lang>
+                "
+                hint-text="
+                    <t-lang en>English hint-text.</t-lang>
+                    <t-lang fr>French hint-text.</t-lang>
+                "
+                error-text="
+                    <t-lang en>English error-text.</t-lang>
+                    <t-lang fr>French error-text.</t-lang>
+                "
+                discrepancy-text="Discrepancy text."
+                warn-text="Warn text."
+                has-warning
+                has-discrepancy
+                invalid
+                required>
+            </tangy-consent>
+
+            <tangy-gps
+                name="gps" 
+                question-number="1." 
+                prompt="
+                    <t-lang en>English prompt.</t-lang>
+                    <t-lang fr>French prompt.</t-lang>
+                "
+                hint-text="
+                    <t-lang en>English hint-text.</t-lang>
+                    <t-lang fr>French hint-text.</t-lang>
+                "
+                error-text="
+                    <t-lang en>English error-text.</t-lang>
+                    <t-lang fr>French error-text.</t-lang>
+                "
+                discrepancy-text="Discrepancy text."
+                warn-text="Warn text."
+                has-warning
+                has-discrepancy
+                invalid
+                required>
+            </tangy-gps>
+
+            <tangy-input
+                name="input" 
+                type="text"
+                question-number="1." 
+                label="
+                    <t-lang en>English label.</t-lang>
+                    <t-lang fr>French label.</t-lang>
+                "
+                hint-text="
+                    <t-lang en>English hint-text.</t-lang>
+                    <t-lang fr>French hint-text.</t-lang>
+                "
+                error-text="
+                    <t-lang en>English error-text.</t-lang>
+                    <t-lang fr>French error-text.</t-lang>
+                "
+                inner-label="
+                    <t-lang en>English inner-label.</t-lang>
+                    <t-lang fr>French inner-label.</t-lang>
+                "
+                discrepancy-text="Discrepancy text."
+                warn-text="Warn text."
+                has-warning
+                has-discrepancy
+                invalid
+                required>
+            </tangy-input>
+          
+            <tangy-input
+                name="input"
+                type="number"
+                question-number="1." 
+                label="
+                    <t-lang en>English label.</t-lang>
+                    <t-lang fr>French label.</t-lang>
+                "
+                hint-text="
+                    <t-lang en>English hint-text.</t-lang>
+                    <t-lang fr>French hint-text.</t-lang>
+                "
+                error-text="
+                    <t-lang en>English error-text.</t-lang>
+                    <t-lang fr>French error-text.</t-lang>
+                "
+                inner-label="
+                    <t-lang en>English inner-label.</t-lang>
+                    <t-lang fr>French inner-label.</t-lang>
+                "
+                discrepancy-text="Discrepancy text."
+                warn-text="Warn text."
+                has-warning
+                has-discrepancy
+                invalid
+                required>
+            </tangy-input>
+
+            <tangy-location
+                name="location" 
+                question-number="1." 
+                label="
+                    <t-lang en>English label.</t-lang>
+                    <t-lang fr>French label.</t-lang>
+                "
+                hint-text="
+                    <t-lang en>English hint-text.</t-lang>
+                    <t-lang fr>French hint-text.</t-lang>
+                "
+                error-text="
+                    <t-lang en>English error-text.</t-lang>
+                    <t-lang fr>French error-text.</t-lang>
+                "
+                location-src="./location-list.json"
+                show-levels="county,school"
+                discrepancy-text="Discrepancy text."
+                warn-text="Warn text."
+                has-warning
+                has-discrepancy
+                invalid
+                required>
+            </tangy-location>
+
+            <tangy-partial-date 
+                name="tangy-partial-date" 
+                question-number="1." 
+                label="
+                    <t-lang en>English label.</t-lang>
+                    <t-lang fr>French label.</t-lang>
+                "
+                hint-text="
+                    <t-lang en>English hint-text.</t-lang>
+                    <t-lang fr>French hint-text.</t-lang>
+                "
+                error-text="
+                    <t-lang en>English error-text.</t-lang>
+                    <t-lang fr>French error-text.</t-lang>
+                "
+                discrepancy-text="Discrepancy text."
+                warn-text="Warn text."
+                has-warning
+                has-discrepancy
+                invalid
+
+                future-date-error-text="
+                <t-lang en>You have entered a date that is in the future but the child's date of birth must be in the past. Please review the date and make an appropriate correction.</t-lang><t-lang fr>
+                Vous avez entré une date future, mais la date de naissance de l'enfant doit être passée. Veuillez revoir la date et apporter une correction appropriée.</t-lang>"
+                required disallow-future-date show-today-button allow-unknown-day allow-unknown-month allow-unknown-year min-year="1990" max-year="2020">
+            </tangy-partial-date>
+        
+            <tangy-photo-capture
+                name="photo-capture" 
+                question-number="1." 
+                label="
+                    <t-lang en>English label.</t-lang>
+                    <t-lang fr>French label.</t-lang>
+                "
+                hint-text="
+                    <t-lang en>English hint-text.</t-lang>
+                    <t-lang fr>French hint-text.</t-lang>
+                "
+                error-text="
+                    <t-lang en>English error-text.</t-lang>
+                    <t-lang fr>French error-text.</t-lang>
+                "
+                discrepancy-text="Discrepancy text."
+                warn-text="Warn text."
+                has-warning
+                has-discrepancy
+                invalid
+                required>
+            </tangy-photo-capture>
+        
+            <tangy-qr
+                name="qr" 
+                question-number="1." 
+                label="
+                    <t-lang en>English label.</t-lang>
+                    <t-lang fr>French label.</t-lang>
+                "
+                hint-text="
+                    <t-lang en>English hint-text.</t-lang>
+                    <t-lang fr>French hint-text.</t-lang>
+                "
+                error-text="
+                    <t-lang en>English error-text.</t-lang>
+                    <t-lang fr>French error-text.</t-lang>
+                "
+                discrepancy-text="Discrepancy text."
+                warn-text="Warn text."
+                has-warning
+                has-discrepancy
+                invalid
+                required>
+            </tangy-qr>
+
+            <tangy-radio-button
+                name="qr" 
+                question-number="1." 
+                label="
+                    <t-lang en>English label.</t-lang>
+                    <t-lang fr>French label.</t-lang>
+                "
+                hint-text="
+                    <t-lang en>English hint-text.</t-lang>
+                    <t-lang fr>French hint-text.</t-lang>
+                "
+                error-text="
+                    <t-lang en>English error-text.</t-lang>
+                    <t-lang fr>French error-text.</t-lang>
+                "
+                discrepancy-text="Discrepancy text."
+                warn-text="Warn text."
+                has-warning
+                has-discrepancy
+                invalid
+                required>
+            </tangy-radio-button>
+                
+            <tangy-radio-buttons
+                name="radio-buttons" 
+                question-number="1." 
+                label="
+                    <t-lang en>English label.</t-lang>
+                    <t-lang fr>French label.</t-lang>
+                "
+                hint-text="
+                    <t-lang en>English hint-text.</t-lang>
+                    <t-lang fr>French hint-text.</t-lang>
+                "
+                error-text="
+                    <t-lang en>English error-text.</t-lang>
+                    <t-lang fr>French error-text.</t-lang>
+                "
+                discrepancy-text="Discrepancy text."
+                warn-text="Warn text."
+                has-warning
+                has-discrepancy
+                invalid
+                required>
+                <option 
+                    value="Z" 
+                    hint-text="
+                        <t-lang en>English hint-text.</t-lang>
+                        <t-lang fr>French hint-text.</t-lang>
+                    "
+                >
+                    <t-lang en>English label.</t-lang>
+                    <t-lang fr>French label.</t-lang>
+                </option>
+                <option value="A">A</option>
+                <option value="B">B</option>
+                <option value="C">C</option>
+                <option value="D">D</option>
+            </tangy-radio-buttons>                              
+                
+            <tangy-select
+                name="tangy-select" 
+                question-number="1." 
+                label="
+                    <t-lang en>English label.</t-lang>
+                    <t-lang fr>French label.</t-lang>
+                "
+                hint-text="
+                    <t-lang en>English hint-text.</t-lang>
+                    <t-lang fr>French hint-text.</t-lang>
+                "
+                error-text="
+                    <t-lang en>English error-text.</t-lang>
+                    <t-lang fr>French error-text.</t-lang>
+                "
+                discrepancy-text="Discrepancy text."
+                warn-text="Warn text."
+                has-warning
+                has-discrepancy
+                invalid
+                required>
+                <option 
+                    value="Z" 
+                    hint-text="
+                        <t-lang en>English hint-text.</t-lang>
+                        <t-lang fr>French hint-text.</t-lang>
+                    "
+                >
+                    <t-lang en>English label.</t-lang>
+                    <t-lang fr>French label.</t-lang>
+                </option>
+                <option value="A">A</option>
+                <option value="B">B</option>
+                <option value="C">C</option>
+                <option value="D">D</option>
+            </tangy-select>        
+     
+        </tangy-form-item>
+
+        <tangy-form-item id="item2" title="Item 2">
+            Test.
+        </tangy-form-item>
+
+    </tangy-form>
+  </body>
+</html>

--- a/input/tangy-checkbox.js
+++ b/input/tangy-checkbox.js
@@ -32,6 +32,8 @@ export class TangyCheckbox extends PolymerElement {
           </label>
         </paper-checkbox>
         <div id="error-text"></div>
+        <div id="warn-text"></div>
+        <div id="discrepancy-text"></div>
       </div>
     </div>
     `
@@ -72,6 +74,18 @@ export class TangyCheckbox extends PolymerElement {
         observer: 'onInvalidChange',
         reflectToAttribute: true
       },
+      hasWarning: {
+        type: Boolean,
+        value: false,
+        observer: 'onWarnChange',
+        reflectToAttribute: true
+      },
+      hasDiscrepancy: {
+        type: Boolean,
+        value: false,
+        observer: 'onDiscrepancyChange',
+        reflectToAttribute: true
+      },
       incomplete: {
         type: Boolean,
         value: true,
@@ -89,6 +103,16 @@ export class TangyCheckbox extends PolymerElement {
         reflectToAttribute: true
       },
       errorText: {
+        type: String,
+        value: '',
+        reflectToAttribute: true
+      },
+      warnText: {
+        type: String,
+        value: '',
+        reflectToAttribute: true
+      },
+      discrepancyText: {
         type: String,
         value: '',
         reflectToAttribute: true
@@ -141,6 +165,18 @@ export class TangyCheckbox extends PolymerElement {
   onInvalidChange(value) {
     this.shadowRoot.querySelector('#error-text').innerHTML = this.invalid
       ? `<iron-icon icon="error"></iron-icon> <div> ${ this.hasAttribute('error-text') ? this.getAttribute('error-text') : ''} </div>`
+      : ''
+  }
+
+  onDiscrepancyChange(value) {
+    this.shadowRoot.querySelector('#discrepancy-text').innerHTML = this.hasDiscrepancy
+      ? `<iron-icon icon="flag"></iron-icon> <div> ${ this.hasAttribute('discrepancy-text') ? this.getAttribute('discrepancy-text') : ''} </div>`
+      : ''
+  }
+
+  onWarnChange(value) {
+    this.shadowRoot.querySelector('#warn-text').innerHTML = this.hasWarning
+      ? `<iron-icon icon="warning"></iron-icon> <div> ${ this.hasAttribute('warn-text') ? this.getAttribute('warn-text') : ''} </div>`
       : ''
   }
 

--- a/input/tangy-checkboxes.js
+++ b/input/tangy-checkboxes.js
@@ -53,6 +53,8 @@ class TangyCheckboxes extends PolymerElement {
           <label id="hint-text" class="hint-text"></label>
           <div id="checkboxes"></div>
           <label id="error-text" class="error-text"></label>
+          <div id="warn-text"></div>
+          <div id="discrepancy-text"></div>
         </div>
       </div>
 
@@ -120,10 +122,32 @@ class TangyCheckboxes extends PolymerElement {
         observer: 'onInvalidChange',
         reflectToAttribute: true
       },
+      hasWarning: {
+        type: Boolean,
+        value: false,
+        observer: 'onWarnChange',
+        reflectToAttribute: true
+      },
+      hasDiscrepancy: {
+        type: Boolean,
+        value: false,
+        observer: 'onDiscrepancyChange',
+        reflectToAttribute: true
+      },
       errorText: {
         type: String,
         value: '',
         observer: 'reflect',
+        reflectToAttribute: true
+      },
+      warnText: {
+        type: String,
+        value: '',
+        reflectToAttribute: true
+      },
+      discrepancyText: {
+        type: String,
+        value: '',
         reflectToAttribute: true
       },
       questionNumber: {
@@ -208,6 +232,18 @@ class TangyCheckboxes extends PolymerElement {
   onInvalidChange(value) {
     this.shadowRoot.querySelector('#error-text').innerHTML = this.invalid
       ? `<iron-icon icon="error"></iron-icon> <div> ${ this.hasAttribute('error-text') ? this.getAttribute('error-text') : ''} </div>`
+      : ''
+  }
+
+  onDiscrepancyChange(value) {
+    this.shadowRoot.querySelector('#discrepancy-text').innerHTML = this.hasDiscrepancy
+      ? `<iron-icon icon="flag"></iron-icon> <div> ${ this.hasAttribute('discrepancy-text') ? this.getAttribute('discrepancy-text') : ''} </div>`
+      : ''
+  }
+
+  onWarnChange(value) {
+    this.shadowRoot.querySelector('#warn-text').innerHTML = this.hasWarning
+      ? `<iron-icon icon="warning"></iron-icon> <div> ${ this.hasAttribute('warn-text') ? this.getAttribute('warn-text') : ''} </div>`
       : ''
   }
 

--- a/input/tangy-consent.js
+++ b/input/tangy-consent.js
@@ -79,6 +79,8 @@ class TangyConsent extends PolymerElement {
             </div>
           </paper-card>
           <div id="error-text"></div>
+          <div id="warn-text"></div>
+          <div id="discrepancy-text"></div>
         </div>
       </div>
   `;
@@ -120,6 +122,18 @@ class TangyConsent extends PolymerElement {
         observer: 'onInvalidChange',
         reflectToAttribute: true
       },
+      hasWarning: {
+        type: Boolean,
+        value: false,
+        observer: 'onWarnChange',
+        reflectToAttribute: true
+      },
+      hasDiscrepancy: {
+        type: Boolean,
+        value: false,
+        observer: 'onDiscrepancyChange',
+        reflectToAttribute: true
+      },
       hintText: {
         type: String,
         value: '',
@@ -127,6 +141,16 @@ class TangyConsent extends PolymerElement {
         reflectToAttribute: true
       },
       errorText: {
+        type: String,
+        value: '',
+        reflectToAttribute: true
+      },
+      warnText: {
+        type: String,
+        value: '',
+        reflectToAttribute: true
+      },
+      discrepancyText: {
         type: String,
         value: '',
         reflectToAttribute: true
@@ -161,6 +185,18 @@ class TangyConsent extends PolymerElement {
   onInvalidChange(value) {
     this.shadowRoot.querySelector('#error-text').innerHTML = this.invalid
       ? `<iron-icon icon="error"></iron-icon> <div> ${ this.hasAttribute('error-text') ? this.getAttribute('error-text') : ''} </div>`
+      : ''
+  }
+
+  onDiscrepancyChange(value) {
+    this.shadowRoot.querySelector('#discrepancy-text').innerHTML = this.hasDiscrepancy
+      ? `<iron-icon icon="flag"></iron-icon> <div> ${ this.hasAttribute('discrepancy-text') ? this.getAttribute('discrepancy-text') : ''} </div>`
+      : ''
+  }
+
+  onWarnChange(value) {
+    this.shadowRoot.querySelector('#warn-text').innerHTML = this.hasWarning
+      ? `<iron-icon icon="warning"></iron-icon> <div> ${ this.hasAttribute('warn-text') ? this.getAttribute('warn-text') : ''} </div>`
       : ''
   }
 

--- a/input/tangy-gps.js
+++ b/input/tangy-gps.js
@@ -127,6 +127,8 @@ class TangyGps extends PolymerElement {
         </div>
         <label class="hint-text"></label>
         <div id="error-text"></div>
+        <div id="warn-text"></div>
+        <div id="discrepancy-text"></div>
       </div>
     </div>
   `;
@@ -205,6 +207,18 @@ class TangyGps extends PolymerElement {
         observer: 'onInvalidChange',
         reflectToAttribute: true
       },
+      hasWarning: {
+        type: Boolean,
+        value: false,
+        observer: 'onWarnChange',
+        reflectToAttribute: true
+      },
+      hasDiscrepancy: {
+        type: Boolean,
+        value: false,
+        observer: 'onDiscrepancyChange',
+        reflectToAttribute: true
+      },
       hintText: {
         type: String,
         value: '',
@@ -212,6 +226,16 @@ class TangyGps extends PolymerElement {
         reflectToAttribute: true
       },
       errorText: {
+        type: String,
+        value: '',
+        reflectToAttribute: true
+      },
+      warnText: {
+        type: String,
+        value: '',
+        reflectToAttribute: true
+      },
+      discrepancyText: {
         type: String,
         value: '',
         reflectToAttribute: true
@@ -249,6 +273,18 @@ class TangyGps extends PolymerElement {
   onInvalidChange(value) {
     this.shadowRoot.querySelector('#error-text').innerHTML = this.invalid
       ? `<iron-icon icon="error"></iron-icon> <div> ${ this.hasAttribute('error-text') ? this.getAttribute('error-text') : ''} </div>`
+      : ''
+  }
+    
+  onDiscrepancyChange(value) {
+    this.shadowRoot.querySelector('#discrepancy-text').innerHTML = this.hasDiscrepancy
+      ? `<iron-icon icon="flag"></iron-icon> <div> ${ this.hasAttribute('discrepancy-text') ? this.getAttribute('discrepancy-text') : ''} </div>`
+      : ''
+  }
+
+  onWarnChange(value) {
+    this.shadowRoot.querySelector('#warn-text').innerHTML = this.hasWarning
+      ? `<iron-icon icon="warning"></iron-icon> <div> ${ this.hasAttribute('warn-text') ? this.getAttribute('warn-text') : ''} </div>`
       : ''
   }
 

--- a/input/tangy-input.js
+++ b/input/tangy-input.js
@@ -39,7 +39,9 @@ export class TangyInput extends PolymerElement {
         <div id="container"></div>
       </div>
     </div>
-
+    <div id="error-text"></div>    
+    <div id="warn-text"></div>
+    <div id="discrepancy-text"></div>
   `
   }
 
@@ -104,6 +106,18 @@ export class TangyInput extends PolymerElement {
         observer: 'onInvalidChange',
         reflectToAttribute: true
       },
+      hasWarning: {
+        type: Boolean,
+        value: false,
+        observer: 'onWarnChange',
+        reflectToAttribute: true
+      },
+      hasDiscrepancy: {
+        type: Boolean,
+        value: false,
+        observer: 'onDiscrepancyChange',
+        reflectToAttribute: true
+      },
       incomplete: {
         type: Boolean,
         value: true,
@@ -150,6 +164,16 @@ export class TangyInput extends PolymerElement {
         type: String,
         observer: 'reflect',
         value: ''
+      },
+      warnText: {
+        type: String,
+        value: '',
+        reflectToAttribute: true
+      },
+      discrepancyText: {
+        type: String,
+        value: '',
+        reflectToAttribute: true
       }
     }
   }
@@ -169,8 +193,6 @@ export class TangyInput extends PolymerElement {
         ? `<paper-input id="input"></paper-input>`
         : `<paper-textarea id="input"></paper-textarea>`
       }
-      <div id="error-text"></div>    
-    
     `
     // Listen for user changes.
     this.shadowRoot.querySelector('#input').addEventListener('value-changed', (event) => {
@@ -249,6 +271,24 @@ export class TangyInput extends PolymerElement {
         : ''
     }
   }
+  
+  onDiscrepancyChange(value) {
+    if (this.shadowRoot.querySelector('#discrepancy-text')) {
+      this.shadowRoot.querySelector('#discrepancy-text').innerHTML = this.hasDiscrepancy
+        ? `<iron-icon icon="flag"></iron-icon> <div> ${ this.hasAttribute('discrepancy-text') ? this.getAttribute('discrepancy-text') : ''} </div>`
+        : ''
+    }
+  }
+
+  onWarnChange(value) {
+    if (this.shadowRoot.querySelector('#warn-text')) {
+      this.shadowRoot.querySelector('#warn-text').innerHTML = this.hasWarning
+        ? `<iron-icon icon="warning"></iron-icon> <div> ${ this.hasAttribute('warn-text') ? this.getAttribute('warn-text') : ''} </div>`
+        : ''
+    }
+  }
+
+
 
   validate() {
     if (this.hasAttribute('disabled') || this.hasAttribute('hidden')) {

--- a/input/tangy-location.js
+++ b/input/tangy-location.js
@@ -460,6 +460,16 @@ class TangyLocation extends PolymerElement {
         type: String,
         value: ''
       },
+      warnText: {
+        type: String,
+        value: '',
+        reflectToAttribute: true
+      },
+      discrepancyText: {
+        type: String,
+        value: '',
+        reflectToAttribute: true
+      },
       value: {
         type: Array,
         value: [],
@@ -475,7 +485,19 @@ class TangyLocation extends PolymerElement {
         type: Boolean,
         value: false,
         reflectToAttribute: true,
-        observer: 'onInvalidChange'
+        observer: 'render'
+      },
+      hasWarning: {
+        type: Boolean,
+        value: false,
+        observer: 'render',
+        reflectToAttribute: true
+      },
+      hasDiscrepancy: {
+        type: Boolean,
+        value: false,
+        observer: 'render',
+        reflectToAttribute: true
       },
       showMetaData: {
         type: Boolean,
@@ -633,19 +655,27 @@ class TangyLocation extends PolymerElement {
       `).join('')}
         ${this.hintText ? `<label id="hint-text" class="hint-text">${this.hintText}</label>` : ``}
         <div id="error-text">
+          ${this.invalid
+            ? `<iron-icon icon="error"></iron-icon> <div> ${ this.hasAttribute('error-text') ? this.getAttribute('error-text') : ''} </div>`
+            : ''
+          }
+        </div>
+        <div id="warn-text">
+          ${this.hasWarning
+            ? `<iron-icon icon="warning"></iron-icon> <div> ${ this.hasAttribute('warn-text') ? this.getAttribute('warn-text') : ''} </div>`
+            : ''
+          }
+        </div>
+        <div id="discrepancy-text">
+          ${this.hasDiscrepancy
+            ? `<iron-icon icon="flag"></iron-icon> <div> ${ this.hasAttribute('discrepancy-text') ? this.getAttribute('discrepancy-text') : ''} </div>`
+            : ''
+          }
         </div>
       </div>
     </div>
     `
 
-  }
-
-  onInvalidChange(value) {
-    if (this.shadowRoot.querySelector('#error-text')) {
-      this.shadowRoot.querySelector('#error-text').innerHTML = this.invalid
-        ? `<iron-icon icon="error"></iron-icon> <div> ${ this.hasAttribute('error-text') ? this.getAttribute('error-text') : ''} </div>`
-        : ''
-    }
   }
 
   calculateLevelOptions(selections, levels) {

--- a/input/tangy-partial-date.js
+++ b/input/tangy-partial-date.js
@@ -59,6 +59,8 @@ class TangyPartialDate extends PolymerElement {
         <div id="container"></div>
       </div>
     </div>
+    <div id="warn-text"></div>
+    <div id="discrepancy-text"></div>
     `;
   }
 
@@ -104,6 +106,18 @@ class TangyPartialDate extends PolymerElement {
         type: Boolean,
         value: false,
         observer: 'render',
+        reflectToAttribute: true
+      },
+     hasWarning: {
+        type: Boolean,
+        value: false,
+        observer: 'onWarnChange',
+        reflectToAttribute: true
+      },
+      hasDiscrepancy: {
+        type: Boolean,
+        value: false,
+        observer: 'onDiscrepancyChange',
         reflectToAttribute: true
       },
       incomplete: {
@@ -179,6 +193,16 @@ class TangyPartialDate extends PolymerElement {
         type: String,
         value: "",
         observer: 'render',
+        reflectToAttribute: true
+      },
+      warnText: {
+        type: String,
+        value: '',
+        reflectToAttribute: true
+      },
+      discrepancyText: {
+        type: String,
+        value: '',
         reflectToAttribute: true
       }
     }
@@ -419,6 +443,20 @@ class TangyPartialDate extends PolymerElement {
       return true;
     }
   }
+  
+  onDiscrepancyChange(value) {
+    this.shadowRoot.querySelector('#discrepancy-text').innerHTML = this.hasDiscrepancy
+      ? `<iron-icon icon="flag"></iron-icon> <div> ${ this.hasAttribute('discrepancy-text') ? this.getAttribute('discrepancy-text') : ''} </div>`
+      : ''
+  }
+
+  onWarnChange(value) {
+    this.shadowRoot.querySelector('#warn-text').innerHTML = this.hasWarning
+      ? `<iron-icon icon="warning"></iron-icon> <div> ${ this.hasAttribute('warn-text') ? this.getAttribute('warn-text') : ''} </div>`
+      : ''
+  }
+
+
 }
 
 window.customElements.define(TangyPartialDate.is, TangyPartialDate);

--- a/input/tangy-photo-capture.js
+++ b/input/tangy-photo-capture.js
@@ -34,6 +34,8 @@ export class TangyPhotoCapture extends PolymerElement {
         <paper-button on-click="capturePhoto"><iron-icon icon="camera-enhance"></iron-icon> capture photo </paper-button>
         <label class="hint-text"></label>
         <div id="error-text"></div>
+        <div id="warn-text"></div>
+        <div id="discrepancy-text"></div>
       </div>
     </div>
     `
@@ -68,6 +70,18 @@ export class TangyPhotoCapture extends PolymerElement {
         observer: 'onDisabledChange',
         reflectToAttribute: true
       },
+      hasWarning: {
+        type: Boolean,
+        value: false,
+        observer: 'onWarnChange',
+        reflectToAttribute: true
+      },
+      hasDiscrepancy: {
+        type: Boolean,
+        value: false,
+        observer: 'onDiscrepancyChange',
+        reflectToAttribute: true
+      },
       hidden: {
         type: Boolean,
         value: false,
@@ -87,6 +101,16 @@ export class TangyPhotoCapture extends PolymerElement {
       value: {
         type: String,
         value: ''
+      },
+      warnText: {
+        type: String,
+        value: '',
+        reflectToAttribute: true
+      },
+      discrepancyText: {
+        type: String,
+        value: '',
+        reflectToAttribute: true
       }
      }
   }
@@ -157,6 +181,18 @@ export class TangyPhotoCapture extends PolymerElement {
     ctx.drawImage(image, 0, 0, newWidth, newHeight);
     newDataUrl = canvas.toDataURL(imageType, imageArguments);
     return newDataUrl;
+  }
+
+  onDiscrepancyChange(value) {
+    this.shadowRoot.querySelector('#discrepancy-text').innerHTML = this.hasDiscrepancy
+      ? `<iron-icon icon="flag"></iron-icon> <div> ${ this.hasAttribute('discrepancy-text') ? this.getAttribute('discrepancy-text') : ''} </div>`
+      : ''
+  }
+
+  onWarnChange(value) {
+    this.shadowRoot.querySelector('#warn-text').innerHTML = this.hasWarning
+      ? `<iron-icon icon="warning"></iron-icon> <div> ${ this.hasAttribute('warn-text') ? this.getAttribute('warn-text') : ''} </div>`
+      : ''
   }
 
 }

--- a/input/tangy-qr.js
+++ b/input/tangy-qr.js
@@ -78,6 +78,8 @@ class TangyQr extends PolymerElement {
         </paper-card>
         <label class="hint-text"></label>
         <div id="error-text"></div>
+        <div id="warn-text"></div>
+        <div id="discrepancy-text"></div>
       </div>
     </div>
     `;
@@ -119,6 +121,18 @@ class TangyQr extends PolymerElement {
         observer: 'onInvalidChange',
         reflectToAttribute: true
       },
+      hasWarning: {
+        type: Boolean,
+        value: false,
+        observer: 'onWarnChange',
+        reflectToAttribute: true
+      },
+      hasDiscrepancy: {
+        type: Boolean,
+        value: false,
+        observer: 'onDiscrepancyChange',
+        reflectToAttribute: true
+      },
       disabled: {
         type: Boolean,
         value: false,
@@ -137,6 +151,16 @@ class TangyQr extends PolymerElement {
       hideOutput: {
         type: Boolean,
         value: false,
+        reflectToAttribute: true
+      },
+      warnText: {
+        type: String,
+        value: '',
+        reflectToAttribute: true
+      },
+      discrepancyText: {
+        type: String,
+        value: '',
         reflectToAttribute: true
       }
     };
@@ -247,6 +271,19 @@ class TangyQr extends PolymerElement {
       return true
     } 
   }
+
+  onDiscrepancyChange(value) {
+    this.shadowRoot.querySelector('#discrepancy-text').innerHTML = this.hasDiscrepancy
+      ? `<iron-icon icon="flag"></iron-icon> <div> ${ this.hasAttribute('discrepancy-text') ? this.getAttribute('discrepancy-text') : ''} </div>`
+      : ''
+  }
+
+  onWarnChange(value) {
+    this.shadowRoot.querySelector('#warn-text').innerHTML = this.hasWarning
+      ? `<iron-icon icon="warning"></iron-icon> <div> ${ this.hasAttribute('warn-text') ? this.getAttribute('warn-text') : ''} </div>`
+      : ''
+  }
+
 }
 
 window.customElements.define('tangy-qr', TangyQr);

--- a/input/tangy-radio-buttons.js
+++ b/input/tangy-radio-buttons.js
@@ -74,6 +74,9 @@ class TangyRadioButtons extends PolymerElement {
           <label class="hint-text"></label>
           <div id="container"></div>
           <label id="error-text"></label>
+          <div id="warn-text"></div>
+          <div id="discrepancy-text"></div>
+
         </div>
       </div>
     `;
@@ -115,6 +118,18 @@ class TangyRadioButtons extends PolymerElement {
         observer: 'reflect',
         reflectToAttribute: true
       },
+      hasWarning: {
+        type: Boolean,
+        value: false,
+        observer: 'onWarnChange',
+        reflectToAttribute: true
+      },
+      hasDiscrepancy: {
+        type: Boolean,
+        value: false,
+        observer: 'onDiscrepancyChange',
+        reflectToAttribute: true
+      },
       hidden: {
         type: Boolean,
         value: false,
@@ -149,6 +164,16 @@ class TangyRadioButtons extends PolymerElement {
         type: String,
         value: '',
         observer: 'reflect',
+        reflectToAttribute: true
+      },
+      warnText: {
+        type: String,
+        value: '',
+        reflectToAttribute: true
+      },
+      discrepancyText: {
+        type: String,
+        value: '',
         reflectToAttribute: true
       }
     }
@@ -263,6 +288,18 @@ class TangyRadioButtons extends PolymerElement {
       this.invalid = false
       return true
     }
+  }
+  
+  onDiscrepancyChange(value) {
+    this.shadowRoot.querySelector('#discrepancy-text').innerHTML = this.hasDiscrepancy
+      ? `<iron-icon icon="flag"></iron-icon> <div> ${ this.hasAttribute('discrepancy-text') ? this.getAttribute('discrepancy-text') : ''} </div>`
+      : ''
+  }
+
+  onWarnChange(value) {
+    this.shadowRoot.querySelector('#warn-text').innerHTML = this.hasWarning
+      ? `<iron-icon icon="warning"></iron-icon> <div> ${ this.hasAttribute('warn-text') ? this.getAttribute('warn-text') : ''} </div>`
+      : ''
   }
 
 }

--- a/input/tangy-select.js
+++ b/input/tangy-select.js
@@ -67,6 +67,18 @@ class TangySelect extends PolymerElement {
         value: false,
         reflectToAttribute: true
       },
+      hasWarning: {
+        type: Boolean,
+        value: false,
+        observer: 'onWarnChange',
+        reflectToAttribute: true
+      },
+      hasDiscrepancy: {
+        type: Boolean,
+        value: false,
+        observer: 'onDiscrepancyChange',
+        reflectToAttribute: true
+      },
       label: {
         type: String,
         value: '',
@@ -108,6 +120,16 @@ class TangySelect extends PolymerElement {
         observer: 'onInvalidChange',
         reflectToAttribute: true
       },
+      warnText: {
+        type: String,
+        value: '',
+        reflectToAttribute: true
+      },
+      discrepancyText: {
+        type: String,
+        value: '',
+        reflectToAttribute: true
+      }
     }
   }
 
@@ -149,6 +171,18 @@ class TangySelect extends PolymerElement {
             : ''
         }
       </label>
+      <div id="warn-text">
+        ${this.hasWarning
+          ? `<iron-icon icon="warning"></iron-icon> <div> ${ this.hasAttribute('warn-text') ? this.getAttribute('warn-text') : ''} </div>`
+          : ''
+        }
+      </div>
+      <div id="discrepancy-text">
+        ${this.hasDiscrepancy
+          ? `<iron-icon icon="flag"></iron-icon> <div> ${ this.hasAttribute('discrepancy-text') ? this.getAttribute('discrepancy-text') : ''} </div>`
+          : ''
+        }
+      </div>
     `
     this._onChangeListener = this
       .shadowRoot

--- a/style/tangy-element-styles.js
+++ b/style/tangy-element-styles.js
@@ -92,6 +92,9 @@ $_documentStyleContainer.innerHTML = `<dom-module id="tangy-element-styles">
         margin-bottom: 5px;
       }
 
+      /*
+       * error-text
+       */
       #error-text, #errorText {
         font-family: var(--paper-font-common-base_-_font-family);
         font-size: medium;
@@ -111,7 +114,53 @@ $_documentStyleContainer.innerHTML = `<dom-module id="tangy-element-styles">
       #error-text:empty, #errorText:empty {
         margin-bottom: 0;
       }
-   
+
+      /*
+       * warn-text
+       */
+      #warn-text {
+        font-family: var(--paper-font-common-base_-_font-family);
+        font-size: medium;
+        font-weight: bold;
+        color: var(--error-color);
+        display: flex;
+        margin-bottom: 30px;
+      }
+      #warn-text > iron-icon {
+        padding-right: 0.8em;
+        height: 24px;
+        width: 24px;
+      }
+      #warn-text > div {
+        line-height: 24px;
+      }
+      #warn-text:empty {
+        margin-bottom: 0;
+      }
+
+      /*
+       * discrepancy-text
+       */
+      #discrepancy-text {
+        font-family: var(--paper-font-common-base_-_font-family);
+        font-size: medium;
+        font-weight: bold;
+        color: var(--error-color);
+        display: flex;
+        margin-bottom: 30px;
+      }
+      #discrepancy-text > iron-icon {
+        padding-right: 0.8em;
+        height: 24px;
+        width: 24px;
+      }
+      #discrepancy-text > div {
+        line-height: 24px;
+      }
+      #discrepancy-text:empty {
+        margin-bottom: 0;
+      }
+
       .secondary_color {
         color: var(--accent-color);
       }

--- a/tangy-form-item.js
+++ b/tangy-form-item.js
@@ -653,7 +653,7 @@ export class TangyFormItem extends PolymerElement {
         return foundNewOrChanged || 
           (
             !this.hadDiscrepancies.find(had => had.name === input.name) ||
-            this.hadDiscrepancies.find(had => had.name === input.name).value !== input.value
+            JSON.stringify(this.hadDiscrepancies.find(had => had.name === input.name).value) !== JSON.stringify(input.value)
           ) 
           ? true
           : false
@@ -663,13 +663,13 @@ export class TangyFormItem extends PolymerElement {
         return foundNewOrChanged || 
           (
             !this.hadWarnings.find(had => had.name === input.name) ||
-            this.hadWarnings.find(had => had.name === input.name).value !== input.value
+            JSON.stringify(this.hadWarnings.find(had => had.name === input.name).value) !== JSON.stringify(input.value)
           ) 
           ? true
           : false
       }, false)
-    this.hadDiscrepancies = hasDiscrepancies
-    this.hadWarnings = hasWarnings
+    this.hadDiscrepancies = JSON.parse(JSON.stringify(hasDiscrepancies))
+    this.hadWarnings = JSON.parse(JSON.stringify(hasWarnings))
     if (invalidInputNames.length !== 0 || hasNewOrChangedDiscrepancies || hasNewOrChangedWarnings) {
       this
         .querySelector(`[name="${firstInputWithIssue}"]`)

--- a/test/tangy-form-item_test.html
+++ b/test/tangy-form-item_test.html
@@ -133,6 +133,27 @@
       </template>
     </test-fixture>
 
+    <test-fixture id="TangyFormItemDiscrepancyIf3Fixture">
+      <template>
+        <tangy-form id="my-form-2" title="My Form 2">
+          <tangy-form-item id="item1">
+            <tangy-radio-buttons
+              name="input1"
+              discrepancy-if="getValue('input1') !== 'yes'"
+              label="Do you like tangerines?"
+            >
+              <option value="maybe">Maybe</option>
+              <option value="no">No</option>
+              <option value="yes">Yes</option>
+            </tangy-radio-buttons>
+            <!--tangy-box show-if="inputs.input1.hasDiscrepancy === true">
+              You really should consider liking tangerines.
+            </tangy-box-->
+          </tangy-form-item>
+        </tangy-form>
+      </template>
+    </test-fixture>
+
     <test-fixture id="TangyFormItemWarnIfFixture">
       <template>
         <tangy-form id="my-form-2" title="My Form 2">
@@ -321,6 +342,24 @@
           assert.equal(element.querySelector('tangy-form-item').querySelector('tangy-input').hasDiscrepancy, true)
           assert.equal(element.querySelector('tangy-form-item').validate(), true)
           assert.equal(element.querySelector('tangy-form-item').querySelector('tangy-input').hasDiscrepancy, true)
+        })
+
+        test('should be invalid from discrepancy-if statement, then still invalid after a failing correction, lastly valid after no correction (complex value)', () => {
+          const element = fixture('TangyFormItemDiscrepancyIf3Fixture');
+          element.newResponse()
+          // Select "maybe", should have discrepancy and item will be invalid.
+          element.querySelector('tangy-form-item').querySelector('tangy-radio-buttons').shadowRoot.querySelectorAll('tangy-radio-button')[0].click()
+          element.querySelector('tangy-form-item').querySelector('tangy-radio-buttons').shadowRoot.querySelectorAll('tangy-radio-button')[0].dispatchEvent(new Event('change', {bubbles:true}))
+          assert.equal(element.querySelector('tangy-form-item').validate(), false)
+          assert.equal(element.querySelector('tangy-form-item').querySelector('tangy-radio-buttons').hasDiscrepancy, true)
+          // Select "no", should have discrepancy and item will still be invalid because the selection changed to another discrepancy qualifying value. 
+          element.querySelector('tangy-form-item').querySelector('tangy-radio-buttons').shadowRoot.querySelectorAll('tangy-radio-button')[1].click()
+          element.querySelector('tangy-form-item').querySelector('tangy-radio-buttons').shadowRoot.querySelectorAll('tangy-radio-button')[1].dispatchEvent(new Event('change', {bubbles:true}))
+          assert.equal(element.querySelector('tangy-form-item').validate(), false)
+          assert.equal(element.querySelector('tangy-form-item').querySelector('tangy-radio-buttons').hasDiscrepancy, true)
+          // Make no selection, discrepancy should remain but item becomes valid because discrepancy value has not changed.
+          assert.equal(element.querySelector('tangy-form-item').validate(), true)
+          assert.equal(element.querySelector('tangy-form-item').querySelector('tangy-radio-buttons').hasDiscrepancy, true)
         })
         
         test('should be invalid from warn-if statement, then continue after no correction, ', () => {

--- a/test/tangy-form-item_test.html
+++ b/test/tangy-form-item_test.html
@@ -103,6 +103,66 @@
       </template>
     </test-fixture>
 
+    <test-fixture id="TangyFormItemDiscrepancyIfFixture">
+      <template>
+        <tangy-form id="my-form-2" title="My Form 2">
+          <tangy-form-item id="item1">
+            <tangy-checkbox name="input1" discrepancy-if="input.value !== 'on'">
+              Do you like tangerines?
+            </tangy-checkbox>
+            <tangy-box show-if="inputs.input1.hasDiscrepancy === true">
+              You really should consider liking tangerines.
+            </tangy-box>
+          </tangy-form-item>
+        </tangy-form>
+      </template>
+    </test-fixture>
+
+    <test-fixture id="TangyFormItemDiscrepancyIf2Fixture">
+      <template>
+        <tangy-form id="my-form-2" title="My Form 2">
+          <tangy-form-item id="item1">
+            <tangy-input name="input1" discrepancy-if="input.value !== 'yes'">
+              Do you like tangerines?
+            </tangy-input>
+            <tangy-box show-if="inputs.input1.hasDiscrepancy === true">
+              You really should consider liking tangerines.
+            </tangy-box>
+          </tangy-form-item>
+        </tangy-form>
+      </template>
+    </test-fixture>
+
+    <test-fixture id="TangyFormItemWarnIfFixture">
+      <template>
+        <tangy-form id="my-form-2" title="My Form 2">
+          <tangy-form-item id="item1">
+            <tangy-checkbox name="input1" warn-if="input.value !== 'on'">
+              Do you like tangerines?
+            </tangy-checkbox>
+            <tangy-box show-if="inputs.input1.hasWarning === true">
+              You really should consider liking tangerines.
+            </tangy-box>
+          </tangy-form-item>
+        </tangy-form>
+      </template>
+    </test-fixture>
+
+    <test-fixture id="TangyFormItemWarnIf2Fixture">
+      <template>
+        <tangy-form id="my-form-2" title="My Form 2">
+          <tangy-form-item id="item1">
+            <tangy-input name="input1" warn-if="input.value !== 'yes'">
+              Do you like tangerines?
+            </tangy-input>
+            <tangy-box show-if="inputs.input1.hasWarning === true">
+              You really should consider liking tangerines.
+            </tangy-box>
+          </tangy-form-item>
+        </tangy-form>
+      </template>
+    </test-fixture>
+
     <test-fixture id="TangyFormItemValidIfTangyIfRadioFixture">
       <template>
         <tangy-form id="my-form-3" title="My Form 3">
@@ -242,6 +302,48 @@
           assert.equal(element.querySelector('tangy-form-item').open, false)
         })
         
+        test('should be invalid from discrepancy-if statement, then continue after no correction, ', () => {
+          const element = fixture('TangyFormItemDiscrepancyIfFixture');
+          element.newResponse()
+          assert.equal(element.querySelector('tangy-form-item').validate(), false)
+          assert.equal(element.querySelector('tangy-form-item').querySelector('tangy-checkbox').hasDiscrepancy, true)
+          assert.equal(element.querySelector('tangy-form-item').validate(), true)
+
+        })
+
+        test('should be invalid from discrepancy-if statement, then still invalid after a failing correction, lastly valid after no correction', () => {
+          const element = fixture('TangyFormItemDiscrepancyIf2Fixture');
+          element.newResponse()
+          assert.equal(element.querySelector('tangy-form-item').validate(), false)
+          assert.equal(element.querySelector('tangy-form-item').querySelector('tangy-input').hasDiscrepancy, true)
+          element.querySelector('tangy-form-item').querySelector('tangy-input').value = 'no'
+          assert.equal(element.querySelector('tangy-form-item').validate(), false)
+          assert.equal(element.querySelector('tangy-form-item').querySelector('tangy-input').hasDiscrepancy, true)
+          assert.equal(element.querySelector('tangy-form-item').validate(), true)
+          assert.equal(element.querySelector('tangy-form-item').querySelector('tangy-input').hasDiscrepancy, true)
+        })
+        
+        test('should be invalid from warn-if statement, then continue after no correction, ', () => {
+          const element = fixture('TangyFormItemWarnIfFixture');
+          element.newResponse()
+          assert.equal(element.querySelector('tangy-form-item').validate(), false)
+          assert.equal(element.querySelector('tangy-form-item').querySelector('tangy-checkbox').hasWarning, true)
+          assert.equal(element.querySelector('tangy-form-item').validate(), true)
+          assert.equal(element.querySelector('tangy-form-item').querySelector('tangy-checkbox').hasWarning, true)
+        })
+
+        test('should be invalid from warn-if statement, then still invalid after a failing correction, lastly valid after no correction', () => {
+          const element = fixture('TangyFormItemWarnIf2Fixture');
+          element.newResponse()
+          assert.equal(element.querySelector('tangy-form-item').validate(), false)
+          assert.equal(element.querySelector('tangy-form-item').querySelector('tangy-input').hasWarning, true)
+          element.querySelector('tangy-form-item').querySelector('tangy-input').value = 'no'
+          assert.equal(element.querySelector('tangy-form-item').validate(), false)
+          assert.equal(element.querySelector('tangy-form-item').querySelector('tangy-input').hasWarning, true)
+          assert.equal(element.querySelector('tangy-form-item').validate(), true)
+          assert.equal(element.querySelector('tangy-form-item').querySelector('tangy-input').hasWarning, true)
+        })
+
         test('should be invalid radio and show custom error message, then continue after correction', () => {
           const sleep = (milliseconds) => new Promise((res) => setTimeout(() => res(true), milliseconds))
           const element = fixture('TangyFormItemValidIfTangyIfRadioFixture');


### PR DESCRIPTION
Related issue: https://github.com/Tangerine-Community/Tangerine/issues/1760

This PR adds support for attributes on all inputs:
- `discrepancy-if`
- `discrepancy-text`
- `warn-if`
- `warning-text`

When a user submits an item, the discrepancy/warn logic would run. If any of them return `true`, the user would be prompted to review and the corresponding messages would be displayed similar to how error-message is displayed. Also, the "next" button would become a "confirm" button. When the user taps the "confirm" button, if they have changed any values of things that were flagged for warning or discrepancy and those changed variables still qualify for discrepancy/warning, they will be prompted again to confirm. Finally, if the user confirms and does not change values of inputs marked as having discrepancy/warning or resolves all warnings and discrepancies, they would be allowed to proceed but the inputs would be saved as still having their `has-discrepancy` and `has-warning` flags on them. After a Form Response is submitted, Tangerine client can then search through a form response and find the flagged variables and create data queries for those with discrepancies.