### PR TITLE
Add support for mutually-exclusive attribute on options in tangy-checkboxes

### DIFF
--- a/input/tangy-checkboxes.js
+++ b/input/tangy-checkboxes.js
@@ -183,6 +183,9 @@ class TangyCheckboxes extends PolymerElement {
     let options = this.querySelectorAll('option')
     for (let option of options) {
       let checkbox = document.createElement('tangy-checkbox')
+      if (option.hasAttribute('mutually-exclusive')) {
+        checkbox.setAttribute('mutually-exclusive', '')
+      }
       if (option.hasAttribute('hint-text')) {
         checkbox.setAttribute('hint-text', option.getAttribute('hint-text'))
       }
@@ -206,11 +209,36 @@ class TangyCheckboxes extends PolymerElement {
   }
 
   onCheckboxClick(event) {
-    let newValue = []
-    this.shadowRoot
-      .querySelectorAll('tangy-checkbox')
-      .forEach(el => newValue.push(el.getProps()))
-    this.value = newValue
+    const mutuallyExlusiveOptionNames = [...this.shadowRoot.querySelectorAll('tangy-checkbox')]
+      .reduce((mutuallyExlusiveOptionNames, option) => {
+        return option.hasAttribute('mutually-exclusive')
+          ? [option.name, ...mutuallyExlusiveOptionNames]
+          : mutuallyExlusiveOptionNames
+      }, [])
+    const previouslySelectedMutuallyExclusiveOption = this.value
+      .find((option) => option.value === 'on' && mutuallyExlusiveOptionNames.includes(option.name))
+    const currentlySelectedMutuallyExclusiveOptionNames = [...this.shadowRoot.querySelectorAll('tangy-checkbox')]
+      .reduce((currentlySelectedMutuallyExclusiveOptionNames, option) => {
+        return option.hasAttribute('mutually-exclusive') && option.getAttribute('value') === 'on'
+          ? [option.name, ...currentlySelectedMutuallyExclusiveOptionNames]
+          : currentlySelectedMutuallyExclusiveOptionNames
+      }, [])
+    if (currentlySelectedMutuallyExclusiveOptionNames.length === 0) {
+      this.value = [...this.shadowRoot.querySelectorAll('tangy-checkbox')]
+        .map(el => { return {name: el.getAttribute('name'), value: el.getAttribute('value')} })
+    } else if (currentlySelectedMutuallyExclusiveOptionNames.length === 1 && !previouslySelectedMutuallyExclusiveOption) {
+      const winningMutuallyExclusiveOptionName = currentlySelectedMutuallyExclusiveOptionNames[0]
+      this.value = [...this.shadowRoot.querySelectorAll('tangy-checkbox')]
+        .map(el => { return {name: el.getAttribute('name'), value: el.getAttribute('name') === winningMutuallyExclusiveOptionName ? 'on' : ''} })
+    } else if (currentlySelectedMutuallyExclusiveOptionNames.length === 1 && previouslySelectedMutuallyExclusiveOption) {
+      const winningMutuallyExclusiveOptionName = currentlySelectedMutuallyExclusiveOptionNames[0]
+      this.value = [...this.shadowRoot.querySelectorAll('tangy-checkbox')]
+        .map(el => { return {name: el.getAttribute('name'), value: el.getAttribute('name') === winningMutuallyExclusiveOptionName ? '' : el.getAttribute('value')} })
+    } else if (currentlySelectedMutuallyExclusiveOptionNames.length > 1) {
+      const winningMutuallyExclusiveOptionName = currentlySelectedMutuallyExclusiveOptionNames.find(name => name !== previouslySelectedMutuallyExclusiveOption.name)
+      this.value = [...this.shadowRoot.querySelectorAll('tangy-checkbox')]
+        .map(el => { return {name: el.getAttribute('name'), value: el.getAttribute('name') === winningMutuallyExclusiveOptionName ? 'on' : ''} })
+    }
     this.dispatchEvent(new CustomEvent('change'))
   }
 

--- a/test/tangy-checkboxes_test.html
+++ b/test/tangy-checkboxes_test.html
@@ -37,17 +37,41 @@
     </test-fixture>
 
     <test-fixture id="TangyCheckboxesHintTextFixture">
-        <template>
-          <tangy-checkboxes name="fruit_selection" label="What is your favorite fruit?">
-            <option value="orange" hint-text='Oranges but not tangerines.'>Orange</option>
-            <option value="banana">Banana</option>
-            <option value="tangerine">Tangerine</option>
-            <option value="cantalope">Cantalope</option>
-            <option value="cherry">Cherry</option>
-            <option value="kiwi">Kiwi</option>
-          </tangy-checkboxes>
-        </template>
-      </test-fixture>
+      <template>
+        <tangy-checkboxes name="fruit_selection" label="What is your favorite fruit?">
+          <option value="orange" hint-text='Oranges but not tangerines.'>Orange</option>
+          <option value="banana">Banana</option>
+          <option value="tangerine">Tangerine</option>
+          <option value="cantalope">Cantalope</option>
+          <option value="cherry">Cherry</option>
+          <option value="kiwi">Kiwi</option>
+        </tangy-checkboxes>
+      </template>
+    </test-fixture>
+
+    <test-fixture id="TangyCheckboxesMutuallyExclusiveFixture">
+      <template>
+        <tangy-checkboxes name="favorite_fruits" label="What are some of your favorite fruits?">
+          <option value="orange">Orange</option>
+          <option value="banana">Banana</option>
+          <option value="tangerine">Tangerine</option>
+          <option value="favorite_is_not_an_option" mutually-exclusive>None of the above.</option>
+        </tangy-checkboxes>
+      </template>
+    </test-fixture>
+ 
+    <test-fixture id="TangyCheckboxesTwoMutuallyExclusiveOptionsFixture">
+      <template>
+        <tangy-checkboxes name="favorite_fruits" label="What are some of your favorite fruits?">
+          <option value="orange">Orange</option>
+          <option value="banana">Banana</option>
+          <option value="tangerine">Tangerine</option>
+          <option value="favorite_is_not_an_option" mutually-exclusive>None of the above.</option>
+          <option value="na" mutually-exclusive>I don't like fruit.</option>
+        </tangy-checkboxes>
+      </template>
+    </test-fixture>
+ 
 
     <script type="module">
       import '../input/tangy-checkboxes.js'
@@ -69,6 +93,59 @@
           const element = fixture('TangyCheckboxesHintTextFixture');
           assert.equal(element.shadowRoot.querySelector('tangy-checkbox').shadowRoot.innerHTML.includes('Oranges'), true)
         })
+
+        test('selecting mutually-exclusive option should remove prior choices', () => {
+          const element = fixture('TangyCheckboxesMutuallyExclusiveFixture');
+          element.shadowRoot.querySelectorAll('tangy-checkbox')[0].value = 'on'
+          element.shadowRoot.querySelectorAll('tangy-checkbox')[0].dispatchEvent(new Event('change', {bubbles:true}))
+          element.shadowRoot.querySelectorAll('tangy-checkbox')[1].value = 'on'
+          element.shadowRoot.querySelectorAll('tangy-checkbox')[1].dispatchEvent(new Event('change', {bubbles:true}))
+          element.shadowRoot.querySelectorAll('tangy-checkbox')[3].value = 'on'
+          element.shadowRoot.querySelectorAll('tangy-checkbox')[3].dispatchEvent(new Event('change', {bubbles:true}))
+          assert.equal(element.shadowRoot.querySelectorAll('tangy-checkbox')[0].value, '')
+          assert.equal(element.shadowRoot.querySelectorAll('tangy-checkbox')[1].value, '')
+          assert.equal(element.shadowRoot.querySelectorAll('tangy-checkbox')[3].value, 'on')
+          assert.equal(element.value[0].value, '')
+          assert.equal(element.value[1].value, '')
+          assert.equal(element.value[3].value, 'on')
+        })
+
+        test('selecting non mutually-exclusive option should remove mutually-exclusive selection', () => {
+          const element = fixture('TangyCheckboxesMutuallyExclusiveFixture');
+         element.shadowRoot.querySelectorAll('tangy-checkbox')[1].value = 'on'
+          element.shadowRoot.querySelectorAll('tangy-checkbox')[1].dispatchEvent(new Event('change', {bubbles:true}))
+          element.shadowRoot.querySelectorAll('tangy-checkbox')[3].value = 'on'
+          element.shadowRoot.querySelectorAll('tangy-checkbox')[3].dispatchEvent(new Event('change', {bubbles:true}))
+          element.shadowRoot.querySelectorAll('tangy-checkbox')[0].value = 'on'
+          element.shadowRoot.querySelectorAll('tangy-checkbox')[0].dispatchEvent(new Event('change', {bubbles:true}))
+          assert.equal(element.shadowRoot.querySelectorAll('tangy-checkbox')[0].value, 'on')
+          assert.equal(element.shadowRoot.querySelectorAll('tangy-checkbox')[1].value, '')
+          assert.equal(element.shadowRoot.querySelectorAll('tangy-checkbox')[3].value, '')
+          assert.equal(element.value[0].value, 'on')
+          assert.equal(element.value[1].value, '')
+          assert.equal(element.value[3].value, '')
+        })
+
+        test('selecting one mutually-exclusive option should remove other mutually-exclusive selection', () => {
+          const element = fixture('TangyCheckboxesTwoMutuallyExclusiveOptionsFixture');
+          element.shadowRoot.querySelectorAll('tangy-checkbox')[0].value = 'on'
+          element.shadowRoot.querySelectorAll('tangy-checkbox')[0].dispatchEvent(new Event('change', {bubbles:true}))
+          element.shadowRoot.querySelectorAll('tangy-checkbox')[1].value = 'on'
+          element.shadowRoot.querySelectorAll('tangy-checkbox')[1].dispatchEvent(new Event('change', {bubbles:true}))
+          element.shadowRoot.querySelectorAll('tangy-checkbox')[3].value = 'on'
+          element.shadowRoot.querySelectorAll('tangy-checkbox')[3].dispatchEvent(new Event('change', {bubbles:true}))
+          element.shadowRoot.querySelectorAll('tangy-checkbox')[4].value = 'on'
+          element.shadowRoot.querySelectorAll('tangy-checkbox')[4].dispatchEvent(new Event('change', {bubbles:true}))
+          assert.equal(element.shadowRoot.querySelectorAll('tangy-checkbox')[0].value, '')
+          assert.equal(element.shadowRoot.querySelectorAll('tangy-checkbox')[1].value, '')
+          assert.equal(element.shadowRoot.querySelectorAll('tangy-checkbox')[3].value, '')
+          assert.equal(element.shadowRoot.querySelectorAll('tangy-checkbox')[4].value, 'on')
+          assert.equal(element.value[0].value, '')
+          assert.equal(element.value[1].value, '')
+          assert.equal(element.value[3].value, '')
+          assert.equal(element.value[4].value, 'on')
+        })
+        
 
       })
     </script>


### PR DESCRIPTION
![Jan-03-2020 13-48-05](https://user-images.githubusercontent.com/156575/71742567-37efed00-2e30-11ea-999c-9afe2e0b9492.gif)

```html
        <tangy-checkboxes name="favorite_fruits" label="What are some of your favorite fruits?">
          <option value="orange">Orange</option>
          <option value="banana">Banana</option>
          <option value="tangerine">Tangerine</option>
          <option value="favorite_is_not_an_option" mutually-exclusive>None of the above.</option>
          <option value="na" mutually-exclusive>I don't like fruit.</option>
        </tangy-checkboxes>
```