### PR TITLE
If time runs out on grids, the last attempted item must not be marked automatically. #1797

### DIFF
--- a/input/tangy-timed.js
+++ b/input/tangy-timed.js
@@ -625,7 +625,6 @@ class TangyTimed extends PolymerElement {
     clearInterval(this.timer2)
     this.isItemCaptured = false
     this.style.background = 'red'
-    this.value = this.value.map((element, i) => Object.assign({}, element, { highlighted: (this.value.length - 1 === i) ? true : false }))
     setTimeout(() => this.style.background = 'white', 200)
     setTimeout(() => this.style.background = 'red', 400)
     setTimeout(() => this.style.background = 'white', 600)


### PR DESCRIPTION
If time runs out on grids the last attempted item must not be marked automatically Tangerine-Community/Tangerine#1797
Removed part of code that set the last item as the last attempted item, thus a user must select the last attempted item when time runs out.