### PR TITLE
Fix endUnixTime not showing up in csv

### DIFF
--- a/tangy-form-reducer.js
+++ b/tangy-form-reducer.js
@@ -243,6 +243,7 @@ const tangyFormReducer = function (state = initialState, action) {
           newState.location = {...newState.location, [locationInfo.level]: locationInfo.value}
         }
       } 
+      newState['lastSaveUnixTime'] = (new Date()).getTime()
       return newState
 
     case 'ITEM_DISABLE':

--- a/tangy-form-reducer.js
+++ b/tangy-form-reducer.js
@@ -242,6 +242,7 @@ const tangyFormReducer = function (state = initialState, action) {
           newState.location = {...newState.location, [locationInfo.level]: locationInfo.value}
         }
       } 
+      newState['endUnixTime']= (new Date()).getTime()
       return newState
 
     case 'ITEM_DISABLE':

--- a/tangy-form-reducer.js
+++ b/tangy-form-reducer.js
@@ -49,6 +49,7 @@ const tangyFormReducer = function (state = initialState, action) {
     case 'FORM_RESPONSE_COMPLETE':
       return Object.assign({}, state, {
         complete: true,
+        endUnixTime: (new Date()).getTime(),
         form: Object.assign({}, state.form, {
           complete: true,
           linearMode: false,
@@ -242,7 +243,6 @@ const tangyFormReducer = function (state = initialState, action) {
           newState.location = {...newState.location, [locationInfo.level]: locationInfo.value}
         }
       } 
-      newState['endUnixTime']= (new Date()).getTime()
       return newState
 
     case 'ITEM_DISABLE':

--- a/tangy-form-reducer.js
+++ b/tangy-form-reducer.js
@@ -49,7 +49,7 @@ const tangyFormReducer = function (state = initialState, action) {
     case 'FORM_RESPONSE_COMPLETE':
       return Object.assign({}, state, {
         complete: true,
-        endUnixTime: (new Date()).getTime(),
+        endUnixtime: Date.now(),
         form: Object.assign({}, state.form, {
           complete: true,
           linearMode: false,
@@ -243,7 +243,7 @@ const tangyFormReducer = function (state = initialState, action) {
           newState.location = {...newState.location, [locationInfo.level]: locationInfo.value}
         }
       } 
-      newState['lastSaveUnixTime'] = (new Date()).getTime()
+      newState['lastSaveUnixtime'] = Date.now()
       return newState
 
     case 'ITEM_DISABLE':

--- a/tangy-form.js
+++ b/tangy-form.js
@@ -364,6 +364,16 @@ export class TangyForm extends PolymerElement {
         type: Number,
         value: undefined,
         reflectToAttribute: true
+      },
+      endUnixtime: {
+        type: Number,
+        value: undefined,
+        reflectToAttribute: true
+      },
+      lastSaveUnixtime: {
+        type: Number,
+        value: undefined,
+        reflectToAttribute: true
       }
     }
   }


### PR DESCRIPTION
`endUnixtime` and `lastSaveUnixtime` should be generated automatically so that it shows up in the `.csv` export.
Fixed by Creating/updating the property on each save.
Closes Tangerine-Community/Tangerine#1790
Needs Tangerine-Community/Tangerine#1865