### PR TITLE
Add TangyPartialDate.diff function to help with calculating relative times from partial dates

### DIFF
--- a/input/tangy-partial-date.js
+++ b/input/tangy-partial-date.js
@@ -4,6 +4,7 @@ import '../style/tangy-element-styles.js';
 import '../style/tangy-common-styles.js'
 import '../style/mdc-select-style.js'
 import { t } from '../util/t.js'
+import moment from 'moment'
 /**
  * `tangy-partial-date`
  *
@@ -467,6 +468,39 @@ class TangyPartialDate extends PolymerElement {
       this.value = this.constructor.properties.value.value
       this.render()
     }
+  }
+
+  _tranformValueToMoment(value) {
+    const [year, month, day] = value.split('-')
+    let date = null
+    if (year === '9999' || year === '') {
+      // Need at least a year to calculate.
+      return null 
+    } else if (month === '99' || month === '') {
+      // We don't have a month, just have a year to go off of.
+      date = moment(year, 'YYYY')
+    } else if (day === '99' || day === '') {
+      // We don't have a day, go off of year and month.
+      date = moment(`${year}-${month}`, 'YYYY-MM')
+    } else {
+      date = moment(`${year}-${month}-${day}`, 'YYYY-MM-DD')
+    }
+    return date
+  }
+
+  getValueAsMoment() {
+    this._tranformValueToMoment(this.value)
+  }
+
+  diff(units = 'days', endString = '', startString = '', asFloat = true) {
+    const end = moment(endString)
+    const start = startString 
+      ? this._tranformValueToMoment(startString)
+      : this.getValueAsMoment()
+    if (!start || !end) {
+      return null
+    }
+    return end.diff(start, units, asFloat)
   }
 
 }

--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
     "@polymer/polymer": "^3.0.0",
     "@zxing/library": "^0.15.1",
     "devtools-detect": "^3.0.0",
+    "moment": "^2.24.0",
     "redux": "^4.0.0",
     "signature_pad": "^3.0.0-beta.3",
     "translation-web-component": "^0.1.1",

--- a/test/tangy-partial-date_test.html
+++ b/test/tangy-partial-date_test.html
@@ -102,7 +102,7 @@
           assert.equal(element.diff('year', moment('2020-01-01'), '2018--'), 2)
         })
 
-        test('should calculate diff with all selected', (done) => {
+        test('should calculate diff with all selected', () => {
           const element = fixture('TangyPartialDateFixture');
           assert.equal(element.diff('year', moment('2020-01-01'), '2019-01-01'), 1)
           assert.equal(element.diff('year', moment('2020-01-01'), '2018-01-01'), 2)

--- a/test/tangy-partial-date_test.html
+++ b/test/tangy-partial-date_test.html
@@ -43,6 +43,7 @@
 
     <script type="module">
       import '../input/tangy-partial-date.js'
+      import moment from 'moment'
       suite('tangy-partial-date', () => {
         test('should reflect value', () => {
           const element = fixture('TangyPartialDateFixture');
@@ -78,6 +79,34 @@
             }
             assert.equal(result, false)
         })
+
+        test('should calculate diff as null with nothing selected or all unknown', () => {
+          const element = fixture('TangyPartialDateFixture');
+          assert.equal(element.diff('year', '2020-01-01', '9999-99-99'), null)
+          assert.equal(element.diff('year', '2020-01-01', '--'), null)
+        })
+
+        test('should calculate diff with only a year selected', () => {
+          const element = fixture('TangyPartialDateFixture');
+          assert.equal(element.diff('year', moment('2020-01-01'), '2019-99-99'), 1)
+          assert.equal(element.diff('year', moment('2020-01-01'), '2018-99-99'), 2)
+          assert.equal(element.diff('year', moment('2020-01-01'), '2019--',), 1)
+          assert.equal(element.diff('year', moment('2020-01-01'), '2018--'), 2)
+        })
+        
+        test('should calculate diff with only a year and month selected', () => {
+          const element = fixture('TangyPartialDateFixture');
+          assert.equal(element.diff('year', moment('2020-01-01'), '2019-99-99'), 1)
+          assert.equal(element.diff('year', moment('2020-01-01'), '2018-99-99'), 2)
+          assert.equal(element.diff('year', moment('2020-01-01'), '2019--'), 1)
+          assert.equal(element.diff('year', moment('2020-01-01'), '2018--'), 2)
+        })
+
+        test('should calculate diff with all selected', (done) => {
+          const element = fixture('TangyPartialDateFixture');
+
+        }).timeout(98765432)
+
       })
     </script>
     

--- a/test/tangy-partial-date_test.html
+++ b/test/tangy-partial-date_test.html
@@ -104,8 +104,9 @@
 
         test('should calculate diff with all selected', (done) => {
           const element = fixture('TangyPartialDateFixture');
-
-        }).timeout(98765432)
+          assert.equal(element.diff('year', moment('2020-01-01'), '2019-01-01'), 1)
+          assert.equal(element.diff('year', moment('2020-01-01'), '2018-01-01'), 2)
+        })
 
       })
     </script>


### PR DESCRIPTION
This PR adds a diff function to TangyPartialDate that will help us with validation. The tricky part is handling when certain parts are unknown. If year is unknown or not filled out, it returns `null` because it can't be calculated from just month and day. See the tests for the different scenarios I'm taking into account.

The parameters of the diff function is... `units = 'days', endString = '', startString = '', asFloat = true`. The default of units is in days. If you don't provide endString, it defaults to now. If you don't provide startString, it defaults the value the user selected. Set asFloat to false if you want whole numbers.

Example:
```html
<tangy-partial-date 
  name="birthday" 
  valid-if="inputs.birthday.diff('year') && inputs.birthday.diff('year') > 21" 
  error-text="You must be older than 21"
>
</tangy-partial-date>
```
