### PR TITLE
Record item first Open times

### DIFF
--- a/tangy-form-item.js
+++ b/tangy-form-item.js
@@ -378,6 +378,11 @@ export class TangyFormItem extends PolymerElement {
         type: Number,
         value: undefined,
         reflectToAttribute: true
+      },
+      firstOpenTime: {
+        type: Number,
+        value: undefined,
+        reflectToAttribute: false
       }
     };
   }
@@ -564,7 +569,6 @@ export class TangyFormItem extends PolymerElement {
     if (open === true && this.innerHTML === '') {
       this.openWithContent(this.template)
     }
-    
   }
 
   openWithContent(contentHTML) {

--- a/tangy-form-reducer.js
+++ b/tangy-form-reducer.js
@@ -24,7 +24,7 @@ const tangyFormReducer = function (state = initialState, action) {
       newState.items = action.itemsInDom.map((itemInDom, index) => {
         let result = newState.items.find(item => item.id === itemInDom.id);
         let merged = { ...itemInDom, ...result }
-        return result ? {...merged}: {itemInDom}
+        return result ? {...merged}: {...itemInDom}
         }
       )
       newState.items[0]['firstOpenTime']= newState.items[0]['firstOpenTime'] ? newState.items[0]['firstOpenTime'] : Date.now()

--- a/tangy-form-reducer.js
+++ b/tangy-form-reducer.js
@@ -18,12 +18,15 @@ const tangyFormReducer = function (state = initialState, action) {
   switch(action.type) {
 
     case 'FORM_OPEN':
+     
       newState = Object.assign({}, action.response)
       // Ensure that the only items we have in the response are those that are in the DOM but maintain state of the existing items in the response.
-      newState.items = action.itemsInDom.map(itemInDom => {
+      newState.items = action.itemsInDom.map((itemInDom, index) => {
         let result = newState.items.find(item => item.id === itemInDom.id);
+        let firstOpenTime;
+        if(index<1 && !itemInDom.firstOpenTime) firstOpenTime = new Date();
         let merged = { ...itemInDom, ...result }
-        return result ? merged: itemInDom
+        return result ? {...merged, firstOpenTime}: {itemInDom, firstOpenTime}
         }
       )
 
@@ -199,6 +202,8 @@ const tangyFormReducer = function (state = initialState, action) {
             props.open = true
           }
           if (action.type === 'ITEM_NEXT' && newState.nextItemId === item.id) {
+            const index = newState.items.findIndex(x=>x.id===newState.nextItemId)
+            if(!newState.items[index].firstOpenTime) item.firstOpenTime = new Date()
             props.open = true
           }
           if (newState.form.hideClosedItems === true && !props.open) {

--- a/tangy-form-reducer.js
+++ b/tangy-form-reducer.js
@@ -23,12 +23,11 @@ const tangyFormReducer = function (state = initialState, action) {
       // Ensure that the only items we have in the response are those that are in the DOM but maintain state of the existing items in the response.
       newState.items = action.itemsInDom.map((itemInDom, index) => {
         let result = newState.items.find(item => item.id === itemInDom.id);
-        let firstOpenTime;
-        if(index<1 && !itemInDom.firstOpenTime) firstOpenTime = new Date();
         let merged = { ...itemInDom, ...result }
-        return result ? {...merged, firstOpenTime}: {itemInDom, firstOpenTime}
+        return result ? {...merged}: {itemInDom}
         }
       )
+      newState.items[0]['firstOpenTime']= newState.items[0]['firstOpenTime'] ? newState.items[0]['firstOpenTime'] : Date.now()
 
       firstNotDisabled = newState.items.findIndex(item => item.disabled === false)
       newState.items[firstNotDisabled].hideBackButton = true
@@ -202,8 +201,7 @@ const tangyFormReducer = function (state = initialState, action) {
             props.open = true
           }
           if (action.type === 'ITEM_NEXT' && newState.nextItemId === item.id) {
-            const index = newState.items.findIndex(x=>x.id===newState.nextItemId)
-            if(!newState.items[index].firstOpenTime) item.firstOpenTime = new Date()
+            if(!item.firstOpenTime) item.firstOpenTime = Date.now()
             props.open = true
           }
           if (newState.form.hideClosedItems === true && !props.open) {

--- a/tangy-form.js
+++ b/tangy-form.js
@@ -364,6 +364,11 @@ export class TangyForm extends PolymerElement {
         type: Number,
         value: undefined,
         reflectToAttribute: true
+      },
+      recordItemFirstOpenTimes: {
+        type: Boolean,
+        value: false,
+        reflectToAttribute: true
       }
     }
   }
@@ -563,7 +568,6 @@ export class TangyForm extends PolymerElement {
     if (state.form && state.form.complete) {
       //this.shadowRoot.querySelector('paper-tabs').selected = (state.form.showSummary) ? '0' : '1'
     }
-
     // Set state in tangy-form-item elements.
     let items = [].slice.call(this.querySelectorAll('tangy-form-item'))
     items.forEach((item) => {


### PR DESCRIPTION
* Fixes Tangerine-Community/Tangerine#1789
* for the first item, record the `on-open` time
* for the subsequent ones, capture after on next.
* Requires the reporting side PR to work. Tangerine-Community/Tangerine#1887
* Needs the `record-item-first-open-times` attribute set on the `<tangy-form>` element
* Needs translation entry for  the string `Record Item First Open Times`
Example: 

``` html 
<tangy-form id="my-form" title="My Form" record-item-first-open-times>
   <tangy-form-item id="item1">
      <tangy-input name="input1" label="What is your first name?"required></tangy-input>
   </tangy-form-item>
 <tangy-form-item id="item2">
     <tangy-input name="input2" label="What is your last name?" required></tangy-input>
 </tangy-form-item>
</tangy-form>
```