### PR TITLE
Fix: hint-text is missing from many inputs when using TangyForm.getMeta()

### DIFF
--- a/input/tangy-acasi.js
+++ b/input/tangy-acasi.js
@@ -46,7 +46,6 @@ export class TangyAcasi extends PolymerElement {
         background-color: var(--paper-indigo-400);
       }
     </style>
-
     <div class="container">
       <label for="group">[[label]]</label>
       <paper-button id="replay" raised class="indigo" on-click="replay">[[t.replay]]</paper-button>

--- a/input/tangy-box.js
+++ b/input/tangy-box.js
@@ -51,7 +51,12 @@ export class TangyBox extends PolymerElement {
         type: Boolean,
         value: false,
         reflectToAttribute: true
-      }
+      },
+      hintText: {
+        type: String,
+        value: '',
+        reflectToAttribute: true
+      },
     }
   }
 

--- a/input/tangy-checkbox.js
+++ b/input/tangy-checkbox.js
@@ -74,6 +74,11 @@ export class TangyCheckbox extends PolymerElement {
         observer: 'onInvalidChange',
         reflectToAttribute: true
       },
+      hintText: {
+        type: String,
+        value: '',
+        reflectToAttribute: true
+      },
       hasWarning: {
         type: Boolean,
         value: false,

--- a/input/tangy-checkbox.js
+++ b/input/tangy-checkbox.js
@@ -22,13 +22,14 @@ export class TangyCheckbox extends PolymerElement {
           --tangy-element-border: 0;
         }
       </style>
+      
     <div class="flex-container">
       <div id="qnum-number"></div>
       <div id="qnum-content">
         <paper-checkbox id="checkbox" id="checkbox">
           <div id="checkbox-text">
           </div>
-          <label class="hint-text">
+          <label id="hint-text" class="hint-text"></label>
           </label>
         </paper-checkbox>
         <div id="error-text"></div>
@@ -77,7 +78,8 @@ export class TangyCheckbox extends PolymerElement {
       hintText: {
         type: String,
         value: '',
-        reflectToAttribute: true
+        reflectToAttribute: true,
+        observer: 'render'
       },
       hasWarning: {
         type: Boolean,
@@ -165,6 +167,7 @@ export class TangyCheckbox extends PolymerElement {
         }
       }))
     })
+    this.$['hint-text'].innerHTML = this.hintText
     this.shadowRoot.querySelector('.hint-text').innerHTML = this.hasAttribute('hint-text') 
       ? this.getAttribute('hint-text') 
       : ''

--- a/input/tangy-checkboxes-dynamic.js
+++ b/input/tangy-checkboxes-dynamic.js
@@ -110,12 +110,6 @@ class TangyCheckboxesDynamic extends PolymerElement {
         type: String,
         value: ''
       },
-      hintText: {
-        type: String,
-        value: '',
-        reflectToAttribute: true,
-        observer:'render'
-      },
       optionsListExcludes: {
         type: String,
         value: ''

--- a/input/tangy-checkboxes-dynamic.js
+++ b/input/tangy-checkboxes-dynamic.js
@@ -113,7 +113,8 @@ class TangyCheckboxesDynamic extends PolymerElement {
       hintText: {
         type: String,
         value: '',
-        reflectToAttribute: true
+        reflectToAttribute: true,
+        observer:'render'
       },
       optionsListExcludes: {
         type: String,

--- a/input/tangy-checkboxes-dynamic.js
+++ b/input/tangy-checkboxes-dynamic.js
@@ -110,6 +110,11 @@ class TangyCheckboxesDynamic extends PolymerElement {
         type: String,
         value: ''
       },
+      hintText: {
+        type: String,
+        value: '',
+        reflectToAttribute: true
+      },
       optionsListExcludes: {
         type: String,
         value: ''

--- a/input/tangy-checkboxes.js
+++ b/input/tangy-checkboxes.js
@@ -78,7 +78,8 @@ class TangyCheckboxes extends PolymerElement {
       hintText: {
         type: String,
         value: '',
-        reflectToAttribute: true
+        reflectToAttribute: true,
+        observer: 'reflect'
       },
       atLeast: {
         type: Number,

--- a/input/tangy-checkboxes.js
+++ b/input/tangy-checkboxes.js
@@ -78,7 +78,6 @@ class TangyCheckboxes extends PolymerElement {
       hintText: {
         type: String,
         value: '',
-        observer: 'reflect',
         reflectToAttribute: true
       },
       atLeast: {

--- a/input/tangy-location.js
+++ b/input/tangy-location.js
@@ -453,7 +453,8 @@ class TangyLocation extends PolymerElement {
       },
       hintText: {
         type: String,
-        value: ''
+        value: '',
+        reflectToAttribute: true
       },
       errorText: {
         type: String,

--- a/input/tangy-qr.js
+++ b/input/tangy-qr.js
@@ -148,6 +148,11 @@ class TangyQr extends PolymerElement {
         observer: 'onSkippedChange',
         reflectToAttribute: true
       },
+      hintText: {
+        type: String,
+        value: '',
+        reflectToAttribute: true
+      },
       statusMessage: {
         type: String,
         value: '',

--- a/input/tangy-radio-button.js
+++ b/input/tangy-radio-button.js
@@ -35,7 +35,9 @@ export class TangyRadioButton extends PolymerElement {
       },
       label: {
         type: String,
-        value: ''
+        value: '',
+        observer: 'render',
+        reflectToAttribute: true
       },
       required: {
         type: Boolean,
@@ -58,6 +60,11 @@ export class TangyRadioButton extends PolymerElement {
       incomplete: {
         type: Boolean,
         value: true,
+        reflectToAttribute: true
+      },
+      hintText: {
+        type: String,
+        value: '',
         reflectToAttribute: true
       },
       hidden: {

--- a/input/tangy-radio-buttons.js
+++ b/input/tangy-radio-buttons.js
@@ -106,9 +106,20 @@ class TangyRadioButtons extends PolymerElement {
         observer: 'reflect',
         reflectToAttribute: true
       },
+      hintText: {
+        type: String,
+        value: '',
+        reflectToAttribute: true
+      },
       required: {
         type: Boolean,
         value: false,
+        observer: 'reflect',
+        reflectToAttribute: true
+      },
+      label: {
+        type: String,
+        value: '',
         observer: 'reflect',
         reflectToAttribute: true
       },

--- a/input/tangy-signature.js
+++ b/input/tangy-signature.js
@@ -103,7 +103,8 @@ export class TangySignature extends PolymerElement {
       },
       hintText: {
         type: String,
-        value: ''
+        value: '',
+        reflectToAttribute: true
       },
       label: {
         type: String,

--- a/input/tangy-toggle-button.js
+++ b/input/tangy-toggle-button.js
@@ -111,6 +111,11 @@ class TangyToggleButton extends PolymerElement {
         value: false,
         reflectToAttribute: true
       },
+      hintText: {
+        type: String,
+        value: '',
+        reflectToAttribute: true
+      },
       identifier: {
         type: Boolean,
         value: false,

--- a/input/tangy-toggle.js
+++ b/input/tangy-toggle.js
@@ -127,6 +127,11 @@ export class TangyToggle extends PolymerElement {
         type: Boolean,
         value: false,
         reflectToAttribute: true
+      },
+      hintText: {
+        type: String,
+        value: '',
+        reflectToAttribute: true
       }
     }
   }


### PR DESCRIPTION
* Add a hint text attribute
* Closes https://github.com/Tangerine-Community/Tangerine/issues/1748