### PR TITLE
fix for conditional logic on checkboxes

### DIFF
--- a/demo/index.html
+++ b/demo/index.html
@@ -137,6 +137,16 @@
                 <option name="afternoon">Afternoon</option>
                 <option name="evening"><i>Evening</i></option>
               </tangy-checkboxes>
+              Again, do you really like any of these fruits?
+              <tangy-checkboxes name="checkboxes_me" required="" question-number="" label="Again, do you like any of these fruits?" hint-text="Check all that apply" error-text="" warn-text="" class="" style="">
+                <option value="1">Banana</option>
+                <option value="2">Apple</option>
+                <option value="3">Durian</option>
+                <option value="4">Avocado</option>
+                <option value="5">Cherry</option>
+                <option value="77" mutually-exclusive="">NA - None of the these fruits are delicious to me</option>
+
+              </tangy-checkboxes>
               Where do you eat fruit?
               <tangy-location
                 name="location"

--- a/input/tangy-checkboxes.js
+++ b/input/tangy-checkboxes.js
@@ -251,7 +251,7 @@ class TangyCheckboxes extends PolymerElement {
     } else if (currentlySelectedMutuallyExclusiveOptionNames.length === 1 && previouslySelectedMutuallyExclusiveOption) {
       const winningMutuallyExclusiveOptionName = currentlySelectedMutuallyExclusiveOptionNames[0]
       this.value = [...this.shadowRoot.querySelectorAll('tangy-checkbox')]
-        .map(el => { return {name: el.getAttribute('name'), value: el.getAttribute('name') === winningMutuallyExclusiveOptionName ? '' : el.getAttribute('value')} })
+        .map(el => { return {name: el.getAttribute('name'), value: el.getAttribute('name') === winningMutuallyExclusiveOptionName ? el.getAttribute('value') : ''} })
     } else if (currentlySelectedMutuallyExclusiveOptionNames.length > 1) {
       const winningMutuallyExclusiveOptionName = currentlySelectedMutuallyExclusiveOptionNames.find(name => name !== previouslySelectedMutuallyExclusiveOption.name)
       this.value = [...this.shadowRoot.querySelectorAll('tangy-checkbox')]


### PR DESCRIPTION
In the bug, when the checkbox w/ the mutual exclusion property is selected, the tangy-form-item detects the change and the onCheckboxClick function is run again. The previouslySelectedMutuallyExclusiveOption value is set, and when it was setting the value it was setting it to '' instead of the previously set value.