### PR TITLE
2418 ethiopian partial date selector

### DIFF
--- a/demo/index.html
+++ b/demo/index.html
@@ -41,7 +41,9 @@
     <script type="module" src="../input/tangy-checkbox.js"></script>
     <script type="module" src="../input/tangy-checkboxes.js"></script>
     <script type="module" src="../input/tangy-checkboxes-dynamic.js"></script>
+    <script type="module" src="../input/tangy-consent.js"></script>
     <script type="module" src="../input/tangy-eftouch.js"></script>
+    <script type="module" src="../input/tangy-ethio-date.js"></script>
     <script type="module" src="../input/tangy-gps.js"></script>
     <script type="module" src="../input/tangy-input.js"></script>
     <script type="module" src="../input/tangy-location.js"></script>
@@ -51,10 +53,9 @@
     <script type="module" src="../input/tangy-timed.js"></script>
     <script type="module" src="../input/tangy-untimed-grid.js"></script>
     <script type="module" src="../input/tangy-toggle-button.js"></script>
+    <script type="module" src="../input/tangy-partial-date.js"></script>
     <script type="module" src="../input/tangy-photo-capture.js"></script>
     <script type="module" src="../input/tangy-qr.js"></script>
-    <script type="module" src="../input/tangy-consent.js"></script>
-    <script type="module" src="../input/tangy-partial-date.js"></script>
 
     <custom-style>
       <style is="custom-style" include="demo-pages-shared-styles">
@@ -273,7 +274,7 @@
                 <option value="yes">Yes</option>
               </tangy-radio-buttons>
               <tangy-input type="text" allowed-pattern="" name="simple" required="" question-number="" label="Simple input"  class="" style=""></tangy-input>
-<!--              <tangy-location name="location" show-levels="county,school" filter-by="school1,school4" location-src="./location-list.json"></tangy-location>-->
+          <!--      <tangy-location name="location" show-levels="county,school" filter-by="school1,school4" location-src="./location-list.json"></tangy-location>-->
           </tangy-form>
         </template>
       </demo-snippet>
@@ -698,6 +699,7 @@
               </tangy-radio-buttons>
             </tangy-form-item>
           </tangy-form>
+        </template>
       </demo-snippet>
 
       <h3>ACASI widget</h3>
@@ -718,6 +720,7 @@
               <tangy-acasi required images="../demo/assets/images/never.png,../demo/assets/images/once.png,../demo/assets/images/few.png,../demo/assets/images/many.png,../demo/assets/images/dont_know.png" incomplete="" introsrc="../demo/assets/sounds/1.mp3" label="" name="pq2" on-change="" touchsrc="../demo/assets/sounds/never_Eng.mp3,../demo/assets/sounds/once_Eng.mp3,../demo/assets/sounds/fewtimes_Eng.mp3,../demo/assets/sounds/manytimes_Eng.mp3,../demo/assets/sounds/noresponse_Eng.mp3" transitionsrc="../demo/assets/sounds/swish.mp3"></tangy-acasi>
             </tangy-form-item>
           </tangy-form>
+        </template>
       </demo-snippet>
 
       <h3>Tangy partial date</h3>
@@ -725,12 +728,31 @@
         <template>
           <tangy-form id="tangy-partial-date-form" title="My Form">
             <tangy-form-item id="tangy-partial-date-item" title="Tangy partial date">
-              <tangy-partial-date valid-if="true" name="input1" label="Test" min-year="2019" max-year="2021" allow-unknown-year show-today-button></tangy-partial-date>
+              <tangy-partial-date valid-if="true" name="input1" label="Test" min-year="2019" max-year="2021" 
+                allow-unknown-year show-today-button></tangy-partial-date>
             </tangy-form-item>
           </tangy-form>
         </template>
       </demo-snippet>
 
+      <h3>Ethiopian Date Picker</h3>
+      <demo-snippet>
+        <template>
+          <tangy-form id="my-form3" title="">
+            <tangy-form-item id="section_month_year" title="Ethiopian Day, Month, Year" on-open="" on-change="" category="">
+              <template>
+                <tangy-ethio-date name="year_month" class="" style="" required="" question-number="" label="Enter a date:"
+                        error-text="" hint-text="" future-date-error-text="No future dates are allowed" 
+                        missing-date-error-text="" invalid-date-error-text="" 
+                        min-year="2010" max-year="2030" show-today-button
+                        disallow-future-date="">
+                </tangy-ethio-date>
+              </template>
+            </tangy-form-item>
+          </tangy-form>
+        </template>
+      </demo-snippet>
+        
     </div>
   </body>
 </html>

--- a/demo/index.html
+++ b/demo/index.html
@@ -744,8 +744,7 @@
                 <tangy-ethio-date name="year_month" class="" style="" required="" question-number="" label="Enter a date:"
                         error-text="" hint-text="" future-date-error-text="No future dates are allowed" 
                         missing-date-error-text="" invalid-date-error-text="" 
-                        min-year="2010" max-year="2030" show-today-button
-                        disallow-future-date="">
+                        min-year="2010" max-year="2030" show-today-button allow-unknown-day allow-unknown-month allow-unknown-year>
                 </tangy-ethio-date>
               </template>
             </tangy-form-item>

--- a/index.js
+++ b/index.js
@@ -18,3 +18,4 @@ import './input/tangy-consent.js';
 import './input/tangy-partial-date.js';
 import './input/tangy-toggle.js';
 import './input/tangy-gate.js';
+import './input/tangy-ethio-date.js';

--- a/input/tangy-ethio-date.js
+++ b/input/tangy-ethio-date.js
@@ -5,15 +5,17 @@ import '../style/tangy-common-styles.js'
 import '../style/mdc-select-style.js'
 import { t } from '../util/t.js'
 import moment from 'moment'
+import * as ethiopianDate from 'ethiopian-date/index.js'
+
 /**
- * `tangy-partial-date`
+ * `tangy-ethio-date`
  *
  *
  * @customElement
  * @polymer
  * @demo demo/index.html
  */
-class TangyPartialDate extends PolymerElement {
+class TangyEthiopianDate extends PolymerElement {
   static get template() {
     return html`
     <style include="tangy-element-styles"></style>
@@ -65,7 +67,7 @@ class TangyPartialDate extends PolymerElement {
     `;
   }
 
-  static get is() { return 'tangy-partial-date'; }
+  static get is() { return 'tangy-ethio-date'; }
 
   static get properties() {
     return {
@@ -230,91 +232,79 @@ class TangyPartialDate extends PolymerElement {
   
   render() {
 
-     const months = [
-      t('January'),
-      t('February'),
-      t('March'),
-      t('April'),
-      t('May'),
-      t('June'),
-      t('July'),
-      t('August'),
-      t('September'),
-      t('October'),
-      t('November'),
-      t('December')
-    ];
-    const days = Array.from({length: 31}, (x,i) => i+1);
+    const months = ['መስከረም', 'ጥቅምት', 'ኅዳር', 'ታህሣሥ', 'ጥር', 'የካቲት', 'መጋቢት', 'ሚያዝያ', 'ግንቦት', 'ሰኔ', 'ሐምሌ', 'ነሐሴ', 'ጳጉሜ'];
+    const days = Array.from({length: 30}, (x,i) => i+1);
+
     const years = Array.from({length: parseInt(this.maxYear) - parseInt(this.minYear) + 1}, (x,i) => parseInt(this.minYear) + i);
     const unknownText = t("Unknown");
-    this.allowUnknownDay && days.push(99);
-    this.allowUnknownMonth && months.push(unknownText);
     this.allowUnknownYear && years.push(9999);
+    this.allowUnknownMonth && months.push(unknownText);
+    this.allowUnknownDay && days.push(99);
 
     this.$['qnum-number'].innerHTML = `<label>${this.questionNumber}</label>`;
     this.$.container.innerHTML = `
-      <label for="group">${this.label}</label>
-      <label class="hint-text">${this.hintText}</label>
-      <div class="mdc-select partial-date-format">
-        <div class='partial-date-float'>
-          <label for='day' class='partial-date-headings'>${t('Day')}:</label>
-          <select class="mdc-select__surface partial-date-select" name="day" value="${this.value}" ${this.disabled ? 'disabled' : ''}>
-            <option value="" default selected disabled></option>
-            ${days.map((day, i) => `
-              <option value="${day}">
-                ${(day === 99 ? t("Unknown") : day)}
-              </option>
-            `)}
-          </select>
-        </div>
-        <div class='partial-date-float'>
-          <label for='month' class='partial-date-headings'>${t('Month')}:</label>
-          <select class="mdc-select__surface partial-date-select" name="month" value="${this.value}" ${this.disabled ? 'disabled' : ''}>
-            <option value="" default selected disabled></option>
-            ${months.map((month, i) => `
-              <option value="${(month === unknownText ? 99 : months.indexOf(month) + 1)}">
-                ${(this.numericMonth ? (month === unknownText ? unknownText : months.indexOf(month) + 1) : (month === unknownText ? unknownText : month))}
-              </option>
-            `)}    
-          </select>
-        </div>
-        <div class='partial-date-float'>
-          <label for='year' class='partial-date-headings'>${t('Year')}:</label>
-            <select class="mdc-select__surface partial-date-select" name="year" value="${this.value}" ${this.disabled ? 'disabled' : ''}>
-              <option value="" default selected disabled></option>
-              ${years.map((year, i) => `
-                <option value="${year}">
-                ${(year === 9999 ? t("Unknown") : year)}
-                </option>
-              `)}
-            </select>
-        </div>  
-        
-        <paper-button style="align-self:flex-end;" id="resetButton">
-            <iron-icon icon="refresh"></iron-icon>&nbsp;
-          </paper-button>
-          
-        ${(this.showTodayButton ? ` 
-          <paper-button style="align-self:flex-end;" id="today" on-click="setToday" ${this.disabled ? 'disabled' : ''}>
-            <iron-icon icon="query-builder"></iron-icon>&nbsp;
-            ${t('Today')}
-          </paper-button>` : '' 
-        )}
+    <label for="group">${this.label}</label>
+    <label class="hint-text">${this.hintText}</label>
+    <div class="mdc-select partial-date-format">
+      <div class='partial-date-float'>
+      <label for='day' class='partial-date-headings'>${t('Day')}:</label>
+        <select class="mdc-select__surface partial-date-select" name="day" value="${this.value}" ${this.disabled ? 'disabled' : ''}>
+          <option value="" default selected disabled></option>
+          ${days.map((day, i) => `
+            <option value="${day}">
+            ${(day === 99 ? t("Unknown") : day)}
+            </option>
+          `)}
+        </select>
       </div>
-      ${this.invalid && this.errorText && !this.internalErrorText ? `
-        <div id="error-text">
-          <iron-icon icon="error"></iron-icon>
-            <div>${this.errorText}</div>
-        </div>      
-      ` : ''}
-      ${this.invalid && this.internalErrorText ? `
-        <div id="error-text">
-          <iron-icon icon="error"></iron-icon>
-            <div>${this.internalErrorText}</div>
-        </div>      
-      ` : ''}
-    `
-    if (this.showTodayButton) {
+      <div class='partial-date-float'>
+        <label for='month' class='partial-date-headings'>${t('Month')}:</label>
+        <select class="mdc-select__surface partial-date-select" name="month" value="${this.value}" ${this.disabled ? 'disabled' : ''}>
+          <option value="" default selected disabled></option>
+          ${months.map((month, i) => `
+            <option value="${(month === unknownText ? 99 : months.indexOf(month) + 1)}">
+              ${(this.numericMonth ? (month === unknownText ? unknownText : months.indexOf(month) + 1) : (month === unknownText ? unknownText : month))}
+            </option>
+          `)}    
+        </select>
+      </div>
+      <div class='partial-date-float'>
+      <label for='year' class='partial-date-headings'>${t('Year')}:</label>
+      <select class="mdc-select__surface partial-date-select" name="year" value="${this.value}" ${this.disabled ? 'disabled' : ''}>
+        <option value="" default selected disabled></option>
+        ${years.map((year, i) => `
+          <option value="${year}">
+            ${(year === 9999 ? t("Unknown") : year)}
+          </option>
+        `)}
+      </select>
+      </div>
+
+      <paper-button style="align-self:flex-end;" id="resetButton">
+          <iron-icon icon="refresh"></iron-icon>&nbsp;
+        </paper-button>
+        
+      ${(this.showTodayButton ? ` 
+        <paper-button style="align-self:flex-end;" id="today" on-click="setToday" ${this.disabled ? 'disabled' : ''}>
+          <iron-icon icon="query-builder"></iron-icon>&nbsp;
+          ${t('Today')}
+        </paper-button>` : '' 
+      )}
+    </div>
+    ${this.invalid && this.errorText && !this.internalErrorText ? `
+      <div id="error-text">
+        <iron-icon icon="error"></iron-icon>
+          <div>${this.errorText}</div>
+      </div>      
+    ` : ''}
+    ${this.invalid && this.internalErrorText ? `
+      <div id="error-text">
+        <iron-icon icon="error"></iron-icon>
+          <div>${this.internalErrorText}</div>
+      </div>      
+    ` : ''}
+  `
+  if (this.showTodayButton) {
       this._onClickListener = this
         .shadowRoot
         .querySelector('#today')
@@ -326,7 +316,7 @@ class TangyPartialDate extends PolymerElement {
       .addEventListener('click', this.onResetClick.bind(this));
     this._onChangeListener = this
       .shadowRoot
-      .querySelector('select[name="day"]')
+      .querySelector('select[name="year"]')
       .addEventListener('change', this.onChange.bind(this));
     this._onChangeListener = this
       .shadowRoot
@@ -334,34 +324,47 @@ class TangyPartialDate extends PolymerElement {
       .addEventListener('change', this.onChange.bind(this));
     this._onChangeListener = this
       .shadowRoot
-      .querySelector('select[name="year"]')
+      .querySelector('select[name="day"]')
       .addEventListener('change', this.onChange.bind(this));
+
     this.dispatchEvent(new CustomEvent('render'))
     if (this.value !== '') {
       const dateValue = this.value;
-      this.shadowRoot.querySelector("select[name='day']").value = this.unpad(dateValue.split("-")[2]);
+      this.shadowRoot.querySelector("select[name='year']").value = dateValue.split("-")[0];
       this.shadowRoot.querySelector("select[name='month']").value = this.unpad(dateValue.split("-")[1]);
-      this.shadowRoot.querySelector("select[name='year']").value = dateValue.split("-")[0];  
+      this.shadowRoot.querySelector("select[name='day']").value = this.unpad(dateValue.split("-")[2]);
+
     }
   }
 
+  /*
+   * onTodayClick(event)
+   * Sets the date to today
+   * The Gregorian Date for today is converted to the equivalent Ethiopian Date
+   */
   onTodayClick(event) {
     const today = new Date();
-    const day = String(today.getDate()).padStart(2, '0');
-    const month = String(today.getMonth() + 1).padStart(2, '0');
-    const year = today.getFullYear();
-    this.value = year + '-' + month + '-' + day;
-    this.shadowRoot.querySelector("select[name='day']").value = year;
+    const date = ethiopianDate.toEthiopian(today.getFullYear(), today.getMonth(), today.getDate());
+
+    const year = String(date[0]) ;
+    const month = String(date[1]);
+    const day = String(date[2]);
+    this.value = year + '-' +  month + '-' + day;
+
+    this.shadowRoot.querySelector("select[name='year']").value =  year;
     this.shadowRoot.querySelector("select[name='month']").value = month;
-    this.shadowRoot.querySelector("select[name='year']").value = day;
+    this.shadowRoot.querySelector("select[name='day']").value = day;
+
     this.render();
   }
 
   onChange(event) {
-    this.value =  this.shadowRoot.querySelector("select[name='year']").value + '-' +
-                  this.pad(this.shadowRoot.querySelector("select[name='month']").value,2) + '-' +
-                  this.pad(this.shadowRoot.querySelector("select[name='day']").value,2);
-    console.log("Date value updated to " + this.value);          
+    const year = this.shadowRoot.querySelector("select[name='year']").value;
+    const month = this.shadowRoot.querySelector("select[name='month']").value;
+    const day = this.shadowRoot.querySelector("select[name='day']").value;
+
+    this.value = year + '-' +  this.pad(month,2) + '-' + this.pad(day,2);
+    
     this.dispatchEvent(new CustomEvent('change'));
   }
 
@@ -400,11 +403,19 @@ class TangyPartialDate extends PolymerElement {
     return +a;
   }
 
+  /*
+   * isFutureDate(dateValue)
+   * Check if the @dateValue is in the future
+   * @dateValue is converted to Gregorian to compare against Date()
+   */
   isFutureDate(dateValue) {
+    const day = parseInt(this.unpad(dateValue.split("-")[2]));
+    const month = parseInt(this.unpad(dateValue.split("-")[1]));
+    const year = parseInt(dateValue.split("-")[0]); 
+
+    const [enteredYear, enteredMonth, enteredDay] = ethiopianDate.toGregorian(year, month, day);
+
     const today = new Date();
-    const enteredDay = parseInt(this.unpad(dateValue.split("-")[2]));
-    const enteredMonth = parseInt(this.unpad(dateValue.split("-")[1]));
-    const enteredYear = parseInt(dateValue.split("-")[0]); 
     if (enteredDay !== 99 && enteredMonth !== 99 && enteredYear !== 9999) {
       const fullDate = new Date(enteredYear, enteredMonth - 1, enteredDay);
       if (fullDate > today) {
@@ -433,35 +444,42 @@ class TangyPartialDate extends PolymerElement {
  
   }
 
+  /*
+   * isValidDate(str)
+   * Validates the selected date based on the Ethiopian Calendar
+   */
   isValidDate(str) {
     var parts = str.split('-');
     if (parts.length < 3)
       return false;
     else {
-      var day = parseInt(parts[2]);
-      var month = parseInt(parts[1]);
       var year = parseInt(parts[0]);
+      var month = parseInt(parts[1]);
+      var day = parseInt(parts[2]);
+
       if (isNaN(day) || isNaN(month) || isNaN(year)) {
           return false;
       }
       if (day < 1 || year < 1)
           return false;
-      if((month>12||month<1) & month !== 99)
+      if((month>13||month<1) & month !== 99)
+          // month out of range
           return false;
-      if ((month == 1 || month == 3 || month == 5 || month == 7 || month == 8 || month == 10 || month == 12) && day > 31 && day !== 99)
+      if ((month != 13) && day > 30 && day !== 99)
+          // First 12 Ethiopians months have 30 days
+          // day out of range
           return false;
-      if ((month == 4 || month == 6 || month == 9 || month == 11 ) && day > 30 & day !== 99)
-          return false;
-      if (month == 2) {
-        if (day === 99)
-          return true;
-        if (((year % 4) == 0 && (year % 100) != 0) || ((year % 400) == 0 && (year % 100) == 0)) {
-            if (day > 29)
-                return false;
-        } else {
-            if (day > 28)
-                return false;
-        }      
+      if (month == 13) {
+          // 13th Ethiopian month has 5 days on a normal year, 6 on a leap year
+          // Ethiopian leap years are one year before gregrian leap years 
+          // (eg: Ethiopian years 2011, 2015, 2019 are leap years)
+          const isLeapYear = (year % 4) === 3
+          if (day === 99) {
+              return true;
+          } else if ((isLeapYear && day > 6) || (!isLeapYear && day > 5)) {
+              // day out of range
+              return false;
+          }
       }
       return true;
     }
@@ -487,18 +505,28 @@ class TangyPartialDate extends PolymerElement {
   }
 
   _tranformValueToMoment(value) {
-    const [year, month, day] = value.split('-')
+    var [year_part, month_part, day_part] = str.split('-');
+
     let date = null
     if (year === '9999' || year === '') {
       // Need at least a year to calculate.
       return null 
     } else if (month === '99' || month === '') {
       // We don't have a month, just have a year to go off of.
+      const greg_date = ethiopian_date.toGregorian(parseInt(year_part), 1, 1);
+      const year = greg_date[0];
       date = moment(year, 'YYYY')
     } else if (day === '99' || day === '') {
       // We don't have a day, go off of year and month.
+      const greg_date = ethiopian_date.toGregorian(parseInt(year_part), parseInt(month_part), 1);
+      const year = greg_date[0];
+      const month = greg_date[1];
       date = moment(`${year}-${month}`, 'YYYY-MM')
     } else {
+      const greg_date = ethiopian_date.toGregorian(parseInt(year_part), parseInt(month_part), parseInt(day_part));
+      const year = greg_date[0];
+      const month = greg_date[1];
+      const day = greg_date[2];
       date = moment(`${year}-${month}-${day}`, 'YYYY-MM-DD')
     }
     return date
@@ -529,4 +557,4 @@ class TangyPartialDate extends PolymerElement {
 
 }
 
-window.customElements.define(TangyPartialDate.is, TangyPartialDate);
+window.customElements.define(TangyEthiopianDate.is, TangyEthiopianDate);

--- a/input/tangy-ethio-date.js
+++ b/input/tangy-ethio-date.js
@@ -462,18 +462,18 @@ class TangyEthiopianDate extends PolymerElement {
       }
       if (day < 1 || year < 1)
           return false;
-      if((month>13||month<1) & month !== 99)
+      if((month>13 || month<1) && month !== 99)
           // month out of range
           return false;
-      if ((month != 13) && day > 30 && day !== 99)
+      if ((month !== 13) && day > 30 && day !== 99)
           // First 12 Ethiopians months have 30 days
           // day out of range
           return false;
-      if (month == 13) {
+      if (month === 13) {
           // 13th Ethiopian month has 5 days on a normal year, 6 on a leap year
           // Ethiopian leap years are one year before gregrian leap years 
           // (eg: Ethiopian years 2011, 2015, 2019 are leap years)
-          const isLeapYear = (year % 4) === 3
+          const isLeapYear = ((year % 4) === 3)
           if (day === 99) {
               return true;
           } else if ((isLeapYear && day > 6) || (!isLeapYear && day > 5)) {
@@ -505,39 +505,37 @@ class TangyEthiopianDate extends PolymerElement {
   }
 
   _tranformValueToMoment(value) {
-    var [year_part, month_part, day_part] = str.split('-');
+    var [year_part, month_part, day_part] = value.split('-');
 
     let date = null
-    if (year === '9999' || year === '') {
+    if (year_part === '9999' || year_part === '') {
       // Need at least a year to calculate.
       return null 
-    } else if (month === '99' || month === '') {
-      // We don't have a month, just have a year to go off of.
-      const greg_date = ethiopian_date.toGregorian(parseInt(year_part), 1, 1);
-      const year = greg_date[0];
-      date = moment(year, 'YYYY')
-    } else if (day === '99' || day === '') {
-      // We don't have a day, go off of year and month.
-      const greg_date = ethiopian_date.toGregorian(parseInt(year_part), parseInt(month_part), 1);
-      const year = greg_date[0];
-      const month = greg_date[1];
-      date = moment(`${year}-${month}`, 'YYYY-MM')
-    } else {
-      const greg_date = ethiopian_date.toGregorian(parseInt(year_part), parseInt(month_part), parseInt(day_part));
-      const year = greg_date[0];
-      const month = greg_date[1];
-      const day = greg_date[2];
-      date = moment(`${year}-${month}-${day}`, 'YYYY-MM-DD')
     }
+    if (month_part === '99' || month_part === '') {
+      // We don't have a month, just have a year to go off of.
+      month_part = '01'
+    }
+    if (day_part === '99' || day_part === '') {
+      // We don't have a day, go off of year and month.
+      day_part = '01'
+    }
+
+    const greg_date = ethiopianDate.toGregorian(parseInt(year_part), parseInt(month_part), parseInt(day_part));
+    const year = greg_date[0];
+    const month = greg_date[1];
+    const day = greg_date[2];
+    date = moment(`${year}-${month}-${day}`, 'YYYY-MM-DD')
+
     return date
   }
 
   getValueAsMoment() {
-    this._tranformValueToMoment(this.value)
+    return this._tranformValueToMoment(this.value)
   }
 
   diff(units = 'days', endString = '', startString = '', asFloat = true) {
-    const end = moment(endString)
+    const end = this._tranformValueToMoment(endString)
     const start = startString 
       ? this._tranformValueToMoment(startString)
       : this.getValueAsMoment()

--- a/input/tangy-partial-date.js
+++ b/input/tangy-partial-date.js
@@ -505,7 +505,7 @@ class TangyPartialDate extends PolymerElement {
   }
 
   getValueAsMoment() {
-    this._tranformValueToMoment(this.value)
+    return this._tranformValueToMoment(this.value)
   }
 
   diff(units = 'days', endString = '', startString = '', asFloat = true) {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1696,6 +1696,11 @@
       "integrity": "sha512-39nnKffWz8xN1BU/2c79n9nB9HDzo0niYUqx6xyqUnyoAnQyyWpOTdZEeiCch8BBu515t4wp9ZmgVfVhn9EBpw==",
       "dev": true
     },
+    "ethiopian-date": {
+      "version": "0.0.6",
+      "resolved": "https://registry.npmjs.org/ethiopian-date/-/ethiopian-date-0.0.6.tgz",
+      "integrity": "sha1-eOqtUDqlGAAnS7mQu4ZCwus8zsc="
+    },
     "events": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/events/-/events-3.1.0.tgz",

--- a/package.json
+++ b/package.json
@@ -26,6 +26,7 @@
     "@zxing/library": "^0.17.1",
     "devtools-detect": "^3.0.0",
     "dr-niels-sortable-list": "git://github.com/DrNiels/sortable-list.git#master",
+    "ethiopian-date": "0.0.6",
     "lit-element": "^2.3.1",
     "moment": "^2.24.0",
     "redux": "^4.0.0",

--- a/test/index.html
+++ b/test/index.html
@@ -29,6 +29,7 @@
         'tangy-list_test.html',
         'tangy-checkboxes-dynamic_test.html',
         'tangy-partial-date_test.html',
+        'tangy-ethio-date_test.html',
         'tangy-list_test.html'
       ]);
     </script>

--- a/test/tangy-ethio-date_test.html
+++ b/test/tangy-ethio-date_test.html
@@ -53,9 +53,9 @@
         test('should show/not show today button', () => {
           const element = fixture('TangyEthiopianDateShowTodayButtonFixture');
           assert.equal(element.getAttribute("show-today-button"), "")
-          assert.equal(!!element.shadowRoot.querySelector("mwc-button[id='today']"),true)
+          assert.equal(!!element.shadowRoot.querySelector("paper-button[id='today']"),true)
           element.removeAttribute("show-today-button")
-          assert.equal(!!element.shadowRoot.querySelector("mwc-button[id='today']"),false)
+          assert.equal(!!element.shadowRoot.querySelector("paper-button[id='today']"),false)
         })
         test('should show/not show unknown year option', () => {
             const element = fixture('TangyEthiopianDateUnknownYear')
@@ -82,30 +82,45 @@
 
         test('should calculate diff as null with nothing selected or all unknown', () => {
           const element = fixture('TangyEthiopianDateFixture');
-          assert.equal(element.diff('year', '2020-01-01', '9999-99-99'), null)
-          assert.equal(element.diff('year', '2020-01-01', '--'), null)
+          assert.equal(element.diff('year', '2019-01-01', '9999-99-99'), null)
+          assert.equal(element.diff('year', '2019-01-01', '--'), null)
         })
 
         test('should calculate diff with only a year selected', () => {
           const element = fixture('TangyEthiopianDateFixture');
-          assert.equal(element.diff('year', moment('2020-01-01'), '2019-99-99'), 1)
-          assert.equal(element.diff('year', moment('2020-01-01'), '2018-99-99'), 2)
-          assert.equal(element.diff('year', moment('2020-01-01'), '2019--',), 1)
-          assert.equal(element.diff('year', moment('2020-01-01'), '2018--'), 2)
+          /*
+           * Strings are Ethiopian dates
+           * end date is 2027-Sept-12
+           * start dates are 2026-(Sept-12) and 2025-(Sept-12) 
+           */
+          assert.equal(element.diff('year', '2019-01-01', '2018-99-99'), 1)
+          assert.equal(element.diff('year', '2019-01-01', '2017-99-99'), 2)
+          assert.equal(element.diff('year', '2019-01-01', '2018--',), 1)
+          assert.equal(element.diff('year', '2019-01-01', '2017--'), 2)
         })
         
         test('should calculate diff with only a year and month selected', () => {
           const element = fixture('TangyEthiopianDateFixture');
-          assert.equal(element.diff('year', moment('2020-01-01'), '2019-99-99'), 1)
-          assert.equal(element.diff('year', moment('2020-01-01'), '2018-99-99'), 2)
-          assert.equal(element.diff('year', moment('2020-01-01'), '2019--'), 1)
-          assert.equal(element.diff('year', moment('2020-01-01'), '2018--'), 2)
+          /*
+           * Strings are Ethiopian dates
+           * end date is 2027-Sept-12
+           * start dates are 2026-(Sept-12) and 2025-(Sept-12) 
+           */
+          assert.equal(element.diff('year', '2019-01-01', '2018-01-99'), 1)
+          assert.equal(element.diff('year', '2019-01-01', '2017-01-99'), 2)
+          assert.equal(element.diff('year', '2019-01-01', '2018-01-',), 1)
+          assert.equal(element.diff('year', '2019-01-01', '2017-01-'), 2)
         })
 
         test('should calculate diff with all selected', () => {
           const element = fixture('TangyEthiopianDateFixture');
-          assert.equal(element.diff('year', moment('2020-01-01'), '2019-01-01'), 1)
-          assert.equal(element.diff('year', moment('2020-01-01'), '2018-01-01'), 2)
+          /*
+           * Strings are Ethiopian dates
+           * end date is 2027-Sept-12
+           * start dates are 2026-(Sept-12) and 2025-(Sept-12) 
+           */
+          assert.equal(element.diff('year', '2019-01-01', '2018-01-01'), 1)
+          assert.equal(element.diff('year', '2019-01-01', '2017-01-01'), 2)
         })
 
       })

--- a/test/tangy-ethio-date_test.html
+++ b/test/tangy-ethio-date_test.html
@@ -1,0 +1,115 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width, minimum-scale=1, initial-scale=1, user-scalable=yes">
+    <title>tangy-ethio-date test</title>
+    <script src="../node_modules/@webcomponents/webcomponentsjs/webcomponents-loader.js"></script>
+    <script src="../node_modules/redux/dist/redux.js"></script>
+    <script src="../node_modules/wct-browser-legacy/browser.js"></script>
+  </head>
+  <body>
+    
+    <test-fixture id="TangyEthiopianDateFixture">
+      <template>
+        <tangy-ethio-date name="test" question-number="25." label="
+                  <t-lang en>Please enter the child's date of birth.</t-lang>
+                  <t-lang fr>S'il vous plaît entrer la date de naissance de l'enfant.</t-lang>"
+                hint-text="
+                  <t-lang en>Please enter the complete date of birth if known. If the complete date of birth is not known, please enter as much information as possible. A partial date is allowed.</t-lang>
+                  <t-lang fr>S'il vous plaît entrer la date de naissance complète si connue. Si la date de naissance complète n'est pas connue, veuillez entrer autant d'informations que possible. Une date partielle est autorisée.</t-lang>"
+                  future-date-error-text="<t-lang en>You have entered a date that is in the future but the child's date of birth must be in the past. Please review the date and make an appropriate correction.</t-lang><t-lang fr>
+                      Vous avez entré une date future, mais la date de naissance de l'enfant doit être passée. Veuillez revoir la date et apporter une correction appropriée.</t-lang>"
+                required disallow-future-date show-today-button allow-unknown-day allow-unknown-month allow-unknown-year min-year="1990" max-year="2020">
+              </tangy-ethio-date> 
+      </template>
+    </test-fixture>
+
+    <test-fixture id="TangyEthiopianDateShowTodayButtonFixture">
+        <template>
+            <tangy-ethio-date name="test" question-number="25." label="Test question"
+            show-today-button >
+            </tangy-ethio-date>
+        </template>
+    </test-fixture>
+
+    <test-fixture id="TangyEthiopianDateUnknownYear">
+        <template>
+            <tangy-ethio-date name="test" question-number="25." label="Test question"
+            show-today-button allow-unknown-year min-year="1990" max-year="2020">
+            </tangy-ethio-date>
+        </template>
+    </test-fixture>
+
+    <script type="module">
+      import '../input/tangy-ethio-date.js'
+      import moment from 'moment'
+      suite('tangy-ethio-date', () => {
+        test('should reflect value', () => {
+          const element = fixture('TangyEthiopianDateFixture');
+          element.value = "2013-09-23"
+          assert.equal(element.shadowRoot.querySelector("select[name='year']").value, "2013")
+        })
+        test('should show/not show today button', () => {
+          const element = fixture('TangyEthiopianDateShowTodayButtonFixture');
+          assert.equal(element.getAttribute("show-today-button"), "")
+          assert.equal(!!element.shadowRoot.querySelector("mwc-button[id='today']"),true)
+          element.removeAttribute("show-today-button")
+          assert.equal(!!element.shadowRoot.querySelector("mwc-button[id='today']"),false)
+        })
+        test('should show/not show unknown year option', () => {
+            const element = fixture('TangyEthiopianDateUnknownYear')
+            assert.equal(element.getAttribute("allow-unknown-year"), "")
+            let result = false
+            let options = Array.from(element.shadowRoot.querySelector("select[name='year']").options)
+            for (let option of options) {
+                if (option.value === "9999") {
+                    result = true
+                }
+            }
+            assert.equal(result, true)
+            element.removeAttribute("allow-unknown-year")
+            result = false
+            assert.equal(element.getAttribute("allow-unknown-year"), null)
+            options = Array.from(element.shadowRoot.querySelector("select[name='year']").options)
+            for (let option of options) {
+                if (option.value === "9999") {
+                    result = true
+                }
+            }
+            assert.equal(result, false)
+        })
+
+        test('should calculate diff as null with nothing selected or all unknown', () => {
+          const element = fixture('TangyEthiopianDateFixture');
+          assert.equal(element.diff('year', '2020-01-01', '9999-99-99'), null)
+          assert.equal(element.diff('year', '2020-01-01', '--'), null)
+        })
+
+        test('should calculate diff with only a year selected', () => {
+          const element = fixture('TangyEthiopianDateFixture');
+          assert.equal(element.diff('year', moment('2020-01-01'), '2019-99-99'), 1)
+          assert.equal(element.diff('year', moment('2020-01-01'), '2018-99-99'), 2)
+          assert.equal(element.diff('year', moment('2020-01-01'), '2019--',), 1)
+          assert.equal(element.diff('year', moment('2020-01-01'), '2018--'), 2)
+        })
+        
+        test('should calculate diff with only a year and month selected', () => {
+          const element = fixture('TangyEthiopianDateFixture');
+          assert.equal(element.diff('year', moment('2020-01-01'), '2019-99-99'), 1)
+          assert.equal(element.diff('year', moment('2020-01-01'), '2018-99-99'), 2)
+          assert.equal(element.diff('year', moment('2020-01-01'), '2019--'), 1)
+          assert.equal(element.diff('year', moment('2020-01-01'), '2018--'), 2)
+        })
+
+        test('should calculate diff with all selected', () => {
+          const element = fixture('TangyEthiopianDateFixture');
+          assert.equal(element.diff('year', moment('2020-01-01'), '2019-01-01'), 1)
+          assert.equal(element.diff('year', moment('2020-01-01'), '2018-01-01'), 2)
+        })
+
+      })
+    </script>
+    
+  </body>
+</html>

--- a/test/tangy-partial-date_test.html
+++ b/test/tangy-partial-date_test.html
@@ -88,24 +88,24 @@
 
         test('should calculate diff with only a year selected', () => {
           const element = fixture('TangyPartialDateFixture');
-          assert.equal(element.diff('year', moment('2020-01-01'), '2019-99-99'), 1)
-          assert.equal(element.diff('year', moment('2020-01-01'), '2018-99-99'), 2)
-          assert.equal(element.diff('year', moment('2020-01-01'), '2019--',), 1)
-          assert.equal(element.diff('year', moment('2020-01-01'), '2018--'), 2)
+          assert.equal(element.diff('year', '2020-01-01', '2019-99-99'), 1)
+          assert.equal(element.diff('year', '2020-01-01', '2018-99-99'), 2)
+          assert.equal(element.diff('year', '2020-01-01', '2019--',), 1)
+          assert.equal(element.diff('year', '2020-01-01', '2018--'), 2)
         })
         
         test('should calculate diff with only a year and month selected', () => {
           const element = fixture('TangyPartialDateFixture');
-          assert.equal(element.diff('year', moment('2020-01-01'), '2019-99-99'), 1)
-          assert.equal(element.diff('year', moment('2020-01-01'), '2018-99-99'), 2)
-          assert.equal(element.diff('year', moment('2020-01-01'), '2019--'), 1)
-          assert.equal(element.diff('year', moment('2020-01-01'), '2018--'), 2)
+          assert.equal(element.diff('year', '2020-01-01', '2019-01-99'), 1)
+          assert.equal(element.diff('year', '2020-01-01', '2018-01-99'), 2)
+          assert.equal(element.diff('year', '2020-01-01', '2019-01-'), 1)
+          assert.equal(element.diff('year', '2020-01-01', '2018-01-'), 2)
         })
 
         test('should calculate diff with all selected', () => {
           const element = fixture('TangyPartialDateFixture');
-          assert.equal(element.diff('year', moment('2020-01-01'), '2019-01-01'), 1)
-          assert.equal(element.diff('year', moment('2020-01-01'), '2018-01-01'), 2)
+          assert.equal(element.diff('year', '2020-01-01', '2019-01-01'), 1)
+          assert.equal(element.diff('year', '2020-01-01', '2018-01-01'), 2)
         })
 
       })


### PR DESCRIPTION
Adds a partial date selector for dates from the Ethiopian Calendar called tangy-ethio-date.

### Ethiopian Calendar
The Ethiopian Calendar has 13 months. The first 12 have 30 days. The 13th month has 5 days on a non-leap year and 6 on a leap year. Leap years occur every four years in the year before a Gregorian leap year. For example, the year 2020 in the Gregorian calendar was a leap year. The Ethiopian leap year took place on 09 September 2019 which was 06-13-2011 in the Ethiopian Calendar. 

### Conversion
The tangy-ethio-date input uses the [ethiopian-date](https://www.npmjs.com/package/ethiopian-date) npm module to convert dates between Ethiopian and Gregorian dates for functions such as using the 'Today' button to set the date to today or to check if the selected date is in the future.

### Stored value
The input values are stored as the string value for the Ethiopian Date, like '2011-13-06'. 