### PR TITLE
Select month from the index returned by the ethiopian-date module

### DIFF
--- a/input/tangy-ethio-date.js
+++ b/input/tangy-ethio-date.js
@@ -342,15 +342,16 @@ class TangyEthiopianDate extends PolymerElement {
    * Sets the date to today
    * The Gregorian Date for today is converted to the equivalent Ethiopian Date
    *
-   * Note: the month value returned by ethiopianDate is an index so it needs to
-   * be increased one to set the month in the value and in the selector
+   * Note: The month value returned by Date() is an index so it needs to
+   * be increased one before converting to ethiopian
    */
   onTodayClick(event) {
     const today = new Date();
-    const date = ethiopianDate.toEthiopian(today.getFullYear(), today.getMonth(), today.getDate());
+    const monthNumber  = (today.getMonth() + 1)
+    const date = ethiopianDate.toEthiopian(today.getFullYear(), monthNumber, today.getDate());
 
     const year = String(date[0]);
-    const month = String(date[1] + 1).padStart(2, '0');
+    const month = String(date[1]).padStart(2, '0');
     const day = String(date[2]).padStart(2, '0');
     this.value = year + '-' +  month + '-' + day;
 

--- a/input/tangy-ethio-date.js
+++ b/input/tangy-ethio-date.js
@@ -510,7 +510,7 @@ class TangyEthiopianDate extends PolymerElement {
     }
   }
 
-  _tranformValueToMoment(value) {
+  _transformValueToMoment(value) {
     var [year_part, month_part, day_part] = value.split('-');
 
     let date = null
@@ -537,13 +537,13 @@ class TangyEthiopianDate extends PolymerElement {
   }
 
   getValueAsMoment() {
-    return this._tranformValueToMoment(this.value)
+    return this._transformValueToMoment(this.value)
   }
 
   diff(units = 'days', endString = '', startString = '', asFloat = true) {
-    const end = this._tranformValueToMoment(endString)
+    const end = this._transformValueToMoment(endString)
     const start = startString 
-      ? this._tranformValueToMoment(startString)
+      ? this._transformValueToMoment(startString)
       : this.getValueAsMoment()
     if (!start || !end) {
       return null

--- a/input/tangy-ethio-date.js
+++ b/input/tangy-ethio-date.js
@@ -341,14 +341,17 @@ class TangyEthiopianDate extends PolymerElement {
    * onTodayClick(event)
    * Sets the date to today
    * The Gregorian Date for today is converted to the equivalent Ethiopian Date
+   *
+   * Note: the month value returned by ethiopianDate is an index so it needs to
+   * be increased one to set the month in the value and in the selector
    */
   onTodayClick(event) {
     const today = new Date();
     const date = ethiopianDate.toEthiopian(today.getFullYear(), today.getMonth(), today.getDate());
 
-    const year = String(date[0]) ;
-    const month = String(date[1]);
-    const day = String(date[2]);
+    const year = String(date[0]);
+    const month = String(date[1] + 1).padStart(2, '0');
+    const day = String(date[2]).padStart(2, '0');
     this.value = year + '-' +  month + '-' + day;
 
     this.shadowRoot.querySelector("select[name='year']").value =  year;

--- a/input/tangy-partial-date.js
+++ b/input/tangy-partial-date.js
@@ -489,7 +489,7 @@ class TangyPartialDate extends PolymerElement {
     }
   }
 
-  _tranformValueToMoment(value) {
+  _transformValueToMoment(value) {
     const [year, month, day] = value.split('-')
     let date = null
     if (year === '9999' || year === '') {
@@ -508,13 +508,13 @@ class TangyPartialDate extends PolymerElement {
   }
 
   getValueAsMoment() {
-    return this._tranformValueToMoment(this.value)
+    return this._transformValueToMoment(this.value)
   }
 
   diff(units = 'days', endString = '', startString = '', asFloat = true) {
     const end = moment(endString)
     const start = startString 
-      ? this._tranformValueToMoment(startString)
+      ? this._transformValueToMoment(startString)
       : this.getValueAsMoment()
     if (!start || !end) {
       return null


### PR DESCRIPTION
The current ethiopian date widget shows the previous month when the 'Today' button is clicked. The cause is that Date() returns an index to the current month, not the number of that month (for example February is '1').  This fix adds one to the index before converting to an ethiopian date. 

It also fixes a spelling mistake in the  transfromValueMoment function