### PR TITLE
Fix dynamically set level tangy location not resuming correctly

### DIFF
--- a/test/tangy-location_test.html
+++ b/test/tangy-location_test.html
@@ -5,6 +5,7 @@
     <meta name="viewport" content="width=device-width, minimum-scale=1, initial-scale=1, user-scalable=yes">
     <title>tangy-location test</title>
     <script src="../node_modules/@webcomponents/webcomponentsjs/webcomponents-loader.js"></script>
+    <script src="../node_modules/redux/dist/redux.js"></script>
     <script src="../node_modules/wct-browser-legacy/browser.js"></script>
   </head>
   <body>
@@ -60,9 +61,45 @@
       </template>
     </test-fixture>
 
+    <test-fixture id="TangyLocationDynamicLevel">
+      <template>
+        <tangy-form id="my-form" title="">
+          <tangy-form-item 
+            id="item1" 
+            title="Item 1" 
+            on-change="   
+              switch (getValue('level_selection')) {
+                case 'county':
+                  inputs.location_selection.setAttribute('show-levels', 'county')
+                  break
+                case 'school':
+                  inputs.location_selection.setAttribute('show-levels', 'county,school')
+                  break
+             }                                                                                                               
+           "
+         >
+           <tangy-radio-buttons 
+             name="level_selection"
+             label="Choose level"
+             required
+           >
+              <option value="county">county</option>
+              <option value="school">school</option>
+            </tangy-radio-buttons>
+            <tangy-location 
+              name="location_selection"
+              location-src="location-list.json"
+            >
+            </tangy-location>
+         </tangy-form-item>
+      </template>
+    </test-fixture>
+
     <script type="module">
       import * as Polymer from '../node_modules/@polymer/polymer/polymer-legacy.js'
       import '../input/tangy-location.js'
+      import '../input/tangy-radio-buttons.js'
+      import '../tangy-form.js'
       suite('tangy-location', () => {
 
         test('should make selection', (done) => {
@@ -118,6 +155,34 @@
             assert.equal(element.shadowRoot.querySelectorAll('select').length, 1)
             assert.equal(element.value.length, 0)
             done()
+          }, {once: true})
+        })
+        test('should resume after dynamic changed levels', (done) => {
+          const element = fixture('TangyLocationDynamicLevel')
+          element.newResponse()
+          element.querySelector('tangy-location').addEventListener('location-list-loaded', () => {
+            element.querySelector('tangy-radio-buttons').value = element.querySelector('tangy-radio-buttons').value.map(option => {
+              return option.name === 'county'
+              ? {
+                ...option,
+                value: 'on'
+              }
+              : {
+                ...option,
+                value: ''
+              }
+            })
+            element.querySelector('tangy-radio-buttons').dispatchEvent(new Event('change', {bubbles: true}))
+            element.querySelector('tangy-location').shadowRoot.querySelectorAll('select')[0].value = 'county2'
+            element.querySelector('tangy-location').shadowRoot.querySelectorAll('select')[0].dispatchEvent(new Event('change', {bubbles: true}))
+            element.querySelector('#item1').shadowRoot.querySelector('#complete').click()
+            element.querySelector('#item1').shadowRoot.querySelector('dom-if').render()
+            element.querySelector('#item1').shadowRoot.querySelector('#open').click()
+            element.querySelector('tangy-location').addEventListener('location-list-loaded', () => {
+              debugger
+              assert.equal(element.querySelector('#item1').querySelector('[name="location_selection"]').value.length, 1)
+              done()
+            })
           }, {once: true})
         })
         test('should populate select list locations found in filterBy', (done) => {

--- a/util/html-element-props.js
+++ b/util/html-element-props.js
@@ -45,5 +45,11 @@ HTMLElement.prototype.setProps = function (props = {}) {
   if (propsObject.hasOwnProperty('locked')) {
     this.locked = propsObject.locked
   }
-  Object.assign(this, propsObject)
+  // Defer some properties being set.
+  if (propsObject.hasOwnProperty('value')) {
+    Object.assign(this, {...propsObject, value: this.value})
+    this.value = propsObject.value
+  } else {
+    Object.assign(this, propsObject)
+  }
 }


### PR DESCRIPTION
When resuming a tangy-location, we call `element.setProps(state)` to set the state. That method internally uses an `Object.assign` which will apply the properties of state in an order that is guaranteed. Because the setter on TangyLocation.showLevels has a need to actually override the TangyLocation.value value, if the order that `Object.assign` sets properties of value then  showLevels, the set on the value will be overridden. This PR modifies `element.setProps` to defer the setting of `element.value` until after the `Object.assign` to avoid this pitfall.