### PR TITLE
Fix "open all" when skipped items

### DIFF
--- a/tangy-form-reducer.js
+++ b/tangy-form-reducer.js
@@ -53,12 +53,15 @@ const tangyFormReducer = function (state = initialState, action) {
       return {
         ...state, 
         items: state.items.map(item => {
-          return !item.disabled
+          return !item.disabled && action.type === 'OPEN_ALL_ITEMS'
             ? {
               ...item,
               open: true
             }
-            : item
+            : {
+              ...item,
+              open: false
+            }
         })
       }
 

--- a/tangy-form-reducer.js
+++ b/tangy-form-reducer.js
@@ -48,6 +48,20 @@ const tangyFormReducer = function (state = initialState, action) {
       if (newState.form.fullscreen === true) newState.items.forEach(item => item.fullscreen = true)
       return newState
 
+    case 'OPEN_ALL_ITEMS':
+    case 'CLOSE_ALL_ITEMS':
+      return {
+        ...state, 
+        items: state.items.map(item => {
+          return !item.disabled
+            ? {
+              ...item,
+              open: true
+            }
+            : item
+        })
+      }
+
     case 'FORM_RESPONSE_COMPLETE':
       return Object.assign({}, state, {
         complete: true,

--- a/tangy-form.js
+++ b/tangy-form.js
@@ -686,7 +686,8 @@ export class TangyForm extends PolymerElement {
     let tangyFormStore = this.store
     let itemEnable = name => this.itemEnable(name)
     let itemDisable = name => this.itemDisable(name)
-    let sectionEnable = name => this.itemEnable(name)
+    let skip = name => this.itemDisable(name)
+    let unskip = name => this.itemEnable(name)
     let sectionDisable = name => this.itemDisable(name)
     let helpers = new TangyFormItemHelpers(this)
     let getValue = (name) => this.getValue(name)

--- a/tangy-form.js
+++ b/tangy-form.js
@@ -314,12 +314,13 @@ export class TangyForm extends PolymerElement {
   }
 
   openAllItems(){
-    this.querySelectorAll("tangy-form-item").forEach(e=>e.shadowRoot.querySelector('#open').click())
+    this.store.dispatch({ type: 'OPEN_ALL_ITEMS' })
     this.shadowRoot.querySelector('#open-all-items').style.display = 'none';
     this.shadowRoot.querySelector('#close-all-items').style.display = 'initial';
   }
+
   closeAllItems(){
-    this.querySelectorAll("tangy-form-item").forEach(e=>e.shadowRoot.querySelector('#close').click())
+    this.store.dispatch({ type: 'CLOSE_ALL_ITEMS' })
     this.shadowRoot.querySelector('#open-all-items').style.display = 'initial';
     this.shadowRoot.querySelector('#close-all-items').style.display = 'none';
   }

--- a/test/tangy-form_test.html
+++ b/test/tangy-form_test.html
@@ -321,7 +321,7 @@
           element.querySelector('#item3').shadowRoot.querySelector('#complete').click()
         })
 
-        test('should open all items', () => {
+        test('should open all items and then close all items', () => {
           const element = fixture('SkipSecondItem');
           element.newResponse()
           element.querySelector('#item1').shadowRoot.querySelector('dom-if').render()
@@ -333,6 +333,12 @@
           assert.equal(
             [...element.querySelectorAll('tangy-form-item')]
               .every(tangyFormItemEl => tangyFormItemEl.hasAttribute('disabled') || tangyFormItemEl.hasAttribute('open'))
+            , true
+          )
+          element.shadowRoot.querySelector('#close-all-items').click()
+          assert.equal(
+            [...element.querySelectorAll('tangy-form-item')]
+              .every(tangyFormItemEl => tangyFormItemEl.hasAttribute('disabled') || !tangyFormItemEl.hasAttribute('open'))
             , true
           )
         })

--- a/test/tangy-form_test.html
+++ b/test/tangy-form_test.html
@@ -274,6 +274,22 @@
       </template>
     </test-fixture>
 
+    <test-fixture id="SkipSecondItem">
+      <template>
+        <tangy-form id="my-form" title="My Form" on-change="skip('item2')">
+          <tangy-form-item id="item1">
+            <tangy-input name="input1" label="What is your last name?"></tangy-input>
+          </tangy-form-item>
+          <tangy-form-item id="item2">
+            <tangy-input name="input2" label="What is your last name?"></tangy-input>
+          </tangy-form-item>
+          <tangy-form-item id="item3">
+            <tangy-input name="input3" label="What is your last name?"></tangy-input>
+          </tangy-form-item>
+        </tangy-form>
+      </template>
+    </test-fixture>
+
 
 
     <script type="module">
@@ -295,18 +311,30 @@
 
       suite('tangy-form', () => {
 
-        test('should open all items', () => {
-          const element = fixture('SimpleTestFixture');
+        test('should skip second item', () => {
+          const element = fixture('SkipSecondItem');
           element.newResponse()
-          element.querySelector('#item-1').shadowRoot.querySelector('dom-if').render()
-          element.querySelector('#item-1').shadowRoot.querySelector('#next').click()
-          element.querySelector('#item-2').shadowRoot.querySelector('dom-if').render()
-          element.querySelector('#item-2').shadowRoot.querySelector('#next').click()
-          element.querySelector('#item-3').shadowRoot.querySelector('dom-if').render()
-          element.querySelector('#item-3').shadowRoot.querySelector('#complete').click()
+          element.querySelector('#item1').shadowRoot.querySelector('dom-if').render()
+          element.querySelector('#item1').shadowRoot.querySelector('#next').click()
+          // If second item wasn't skipped, the following would fail.
+          element.querySelector('#item3').shadowRoot.querySelector('dom-if').render()
+          element.querySelector('#item3').shadowRoot.querySelector('#complete').click()
+        })
+
+        test('should open all items', () => {
+          const element = fixture('SkipSecondItem');
+          element.newResponse()
+          element.querySelector('#item1').shadowRoot.querySelector('dom-if').render()
+          element.querySelector('#item1').shadowRoot.querySelector('#next').click()
+          element.querySelector('#item3').shadowRoot.querySelector('dom-if').render()
+          element.querySelector('#item3').shadowRoot.querySelector('#complete').click()
           element.shadowRoot.querySelector('dom-if').render()
           element.shadowRoot.querySelector('#open-all-items').click()
-          assert.equal([...element.querySelectorAll('tangy-form-item')].every(tangyFormItemEl => tangyFormItemEl.hasAttribute('open')), true)
+          assert.equal(
+            [...element.querySelectorAll('tangy-form-item')]
+              .every(tangyFormItemEl => tangyFormItemEl.hasAttribute('disabled') || tangyFormItemEl.hasAttribute('open'))
+            , true
+          )
         })
 
         test('should unlock', () => {


### PR DESCRIPTION
If there is a skipped tangy-form-item, "open all" only works up until that skipped item leaving any proceeding items unopened.

The arrow on the right points to an error generated by trying to click the open button on a skipped tangy-form-item. Skipped tangy-form-item's do not have open buttons. The arrow on the left points to the tangy-form-item that was not skipped but does not open because the code crashed before it could be opened.

<img width="1956" alt="Screen Shot 2021-02-22 at 7 08 36 AM" src="https://user-images.githubusercontent.com/156575/108708395-653da580-74df-11eb-8cb4-81ed27bc8b09.png">
