### PR TITLE
Grid auto stop

### DIFF
--- a/input/tangy-timed.js
+++ b/input/tangy-timed.js
@@ -628,7 +628,9 @@ class TangyTimed extends PolymerElement {
     setTimeout(() => this.style.background = 'white', 200)
     setTimeout(() => this.style.background = 'red', 400)
     setTimeout(() => this.style.background = 'white', 600)
-    setTimeout(() => alert(t('Please tap on last item attempted.')), 800)
+    if(!this.gridAutoStopped){
+      setTimeout(() => alert(t('Please tap on last item attempted.')), 800)
+    }
     this.mode = TANGY_TIMED_MODE_LAST_ATTEMPTED
   }
   rowMarkerClicked(rowNumber) {
@@ -724,8 +726,8 @@ class TangyTimed extends PolymerElement {
     }
     if (this.autoStop && this.shouldGridAutoStop()) {
       event.target.highlighted = true
-      this.stopGrid()
       this.gridAutoStopped = true
+      this.stopGrid()
       this.onStopClick(null, event.target.name)
     }
   }

--- a/input/tangy-timed.js
+++ b/input/tangy-timed.js
@@ -775,6 +775,7 @@ class TangyTimed extends PolymerElement {
   }
 
   reset() {
+    this.gridAutoStopped = false
     this.value = this.value.map(option => {
       option.highlighted = false
       option.captured = false


### PR DESCRIPTION
* Closes Tangerine-Community/Tangerine#2559
* Closes Tangerine-Community/Tangerine#2467
* Set grid autoStopped to false when grid is reset
*  Remove alert dialog asking to mark last item attempted when grid is auto-stopped as it doesnt make sense in the context