### PR TITLE
Add sectionEnable function back to tangy-form

### DIFF
--- a/tangy-form.js
+++ b/tangy-form.js
@@ -689,6 +689,7 @@ export class TangyForm extends PolymerElement {
     let itemDisable = name => this.itemDisable(name)
     let skip = name => this.itemDisable(name)
     let unskip = name => this.itemEnable(name)
+    let sectionEnable = name => this.itemEnable(name)
     let sectionDisable = name => this.itemDisable(name)
     let helpers = new TangyFormItemHelpers(this)
     let getValue = (name) => this.getValue(name)


### PR DESCRIPTION
Looks like `sectionEnable` function was dropped in v4.23.0 (Bad merge?).  I noticed this because calling 'sectionEnable' is no longer a function in tangerine-preview

```
commit 5317dce6890f7b79558a31cbda26dfa16080b764
Author: R.J. Steinert <rj@rjsteinert.com>
Date:   Mon Feb 22 07:23:56 2021 -0500

    Add skip and unskip to tangy-form callback helpers

diff --git a/tangy-form.js b/tangy-form.js
index 8385f1f..5282d79 100644
--- a/tangy-form.js
+++ b/tangy-form.js
@@ -686,7 +686,8 @@ export class TangyForm extends PolymerElement {
     let tangyFormStore = this.store
     let itemEnable = name => this.itemEnable(name)
     let itemDisable = name => this.itemDisable(name)
-    let sectionEnable = name => this.itemEnable(name)
+    let skip = name => this.itemDisable(name)
+    let unskip = name => this.itemEnable(name)
     let sectionDisable = name => this.itemDisable(name)
     let helpers = new TangyFormItemHelpers(this)
     let getValue = (name) => this.getValue(name)
```