### PR TITLE
Add support for shrinking form responses

### DIFF
--- a/tangy-form.js
+++ b/tangy-form.js
@@ -66,13 +66,20 @@ export class TangyForm extends PolymerElement {
   // Set a form response to this property to resume a form response.
   set response(value) {
     this._responseHasBeenSet = true
-    this.store.dispatch({ type: 'FORM_OPEN', response: value, itemsInDom: [...this.querySelectorAll('tangy-form-item')].map(itemEl => itemEl.getProps())})
+    const response = new TangyFormResponseModel(value)
+    this.store.dispatch({ type: 'FORM_OPEN', response: response, itemsInDom: [...this.querySelectorAll('tangy-form-item')].map(itemEl => itemEl.getProps())})
     this.fireHook('on-open')
   }
 
   // Get the current form response.
   get response() {
     return (this._responseHasBeenSet) ? this.store.getState() : null 
+  }
+
+  get shrunkResponse() {
+    return (this._responseHasBeenSet)
+      ? (new TangyFormResponseModel(this.store.getState())).getShrunkResponse()
+      : null 
   }
 
   // Get an array of all inputs across items.

--- a/test/tangy-form_test.html
+++ b/test/tangy-form_test.html
@@ -91,10 +91,15 @@
       <template>
         <tangy-form id="test" title="test">
           <tangy-form-item id="item-1">
-            <tangy-input label='test1' name='input1'></tangy-input>
+            <tangy-input 
+              label='Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.'
+              inner-label="test1"
+              name='input1'
+            >
+            </tangy-input>
           </tangy-form-item>
           <tangy-form-item id="item-2">
-            <tangy-input label='test2' name='input2'></tangy-input>
+            <tangy-input label='test2' inner-label="test2" name='input2'></tangy-input>
           </tangy-form-item>
         </tangy-form>
       </template>
@@ -310,6 +315,31 @@
       })
 
       suite('tangy-form', () => {
+
+        test('should shrink and unshrink response', () => {
+          const element = fixture('Simple2ItemFixture');
+          element.newResponse()
+          element.querySelector('#item-1').shadowRoot.querySelector('dom-if').render()
+          element.querySelector('#item-1').querySelector('[name=input1]').value = 'foo'
+          element.querySelector('#item-1').shadowRoot.querySelector('#next').click()
+          element.querySelector('#item-2').shadowRoot.querySelector('dom-if').render()
+          element.querySelector('#item-2').querySelector('[name=input2]').value = 'bar'
+          element.querySelector('#item-2').shadowRoot.querySelector('#complete').click()
+          const shrunkResponse = element.shrunkResponse
+          const bigResponse = element.response
+          assert.equal(shrunkResponse.items[0].inputs[0].v, 'foo')
+          assert.equal(shrunkResponse.items[1].inputs[0].v, 'bar')
+          assert.equal(bigResponse.items[0].inputs[0].value, 'foo')
+          assert.equal(bigResponse.items[1].inputs[0].value, 'bar')
+          const element2 = fixture('Simple2ItemFixture');
+          element2.response = shrunkResponse
+          element2.querySelector('#item-1').shadowRoot.querySelector('dom-if').render()
+          element2.querySelector('#item-1').shadowRoot.querySelector('#open').click()
+          assert.equal(element2.querySelector('#item-1').querySelector('[name=input1]').value, 'foo')
+          element2.querySelector('#item-2').shadowRoot.querySelector('dom-if').render()
+          element2.querySelector('#item-2').shadowRoot.querySelector('#open').click()
+          assert.equal(element2.querySelector('#item-2').querySelector('[name=input2]').value, 'bar')
+        })
 
         test('should skip second item', () => {
           const element = fixture('SkipSecondItem');


### PR DESCRIPTION
This PR adds support for getting a shrunk Tangy Form Response and automatic detection when a shrunk Tangy Form Response is set on a Tangy Form. It shrink by abbreviating common property names on inputs as well as removing unnecessary properties such as `label`. 

Example of an input, big vs. shrunk:

![image](https://user-images.githubusercontent.com/156575/110120350-eff98c80-7d8a-11eb-8811-93a3ee9fa490.png)
