### PR TITLE
Makes image capture work with a max size attribute

### DIFF
--- a/demo/tangy-photo-capture.html
+++ b/demo/tangy-photo-capture.html
@@ -1,0 +1,80 @@
+<!doctype html>
+<html lang="en">
+
+<head>
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width, minimum-scale=1, initial-scale=1, user-scalable=yes">
+
+    <title>tangy-photo-capture demo</title>
+
+    <script src="../node_modules/@webcomponents/webcomponentsjs/webcomponents-loader.js"></script>
+    <script src="../node_modules/devtools-detect/index.js"></script>
+    <script src="../node_modules/redux/dist/redux.min.js"></script>
+
+    <script type="module">
+        import '@polymer/iron-demo-helpers/demo-pages-shared-styles';
+        import '@polymer/iron-demo-helpers/demo-snippet';
+    </script>
+    <custom-style>
+        <style>
+            html {
+                --document-background-color: #FAFAFA;
+                --primary-color-dark: #3c5b8d;
+                --primary-text-color: var(--light-theme-text-color);
+                --primary-color: #3c5b8d;
+                --accent-color: #f26f10;
+                --accent-text-color: #FFF;
+                --error-color: var(--paper-red-500);
+                --disabled-color: #BBB;
+            }
+
+            h1,
+            h2,
+            h3,
+            h4,
+            h5 {
+                @apply --paper-font-common-base;
+                color: var(--primary-text-color);
+                margin: 25px 0px 5px 15px;
+            }
+        </style>
+    </custom-style>
+    <script type="module" src="../tangy-form.js"></script>
+    <script type="module" src="../input/tangy-acasi.js"></script>
+    <script type="module" src="../input/tangy-box.js"></script>
+    <script type="module" src="../input/tangy-checkbox.js"></script>
+    <script type="module" src="../input/tangy-checkboxes.js"></script>
+    <script type="module" src="../input/tangy-checkboxes-dynamic.js"></script>
+    <script type="module" src="../input/tangy-eftouch.js"></script>
+    <script type="module" src="../input/tangy-gps.js"></script>
+    <script type="module" src="../input/tangy-input.js"></script>
+    <script type="module" src="../input/tangy-location.js"></script>
+    <script type="module" src="../input/tangy-radio-button.js"></script>
+    <script type="module" src="../input/tangy-radio-buttons.js"></script>
+    <script type="module" src="../input/tangy-select.js"></script>
+    <script type="module" src="../input/tangy-timed.js"></script>
+    <script type="module" src="../input/tangy-untimed-grid.js"></script>
+    <script type="module" src="../input/tangy-toggle-button.js"></script>
+    <script type="module" src="../input/tangy-photo-capture.js"></script>
+    <script type="module" src="../input/tangy-qr.js"></script>
+    <script type="module" src="../input/tangy-consent.js"></script>
+    <script type="module" src="../input/tangy-signature.js"></script>
+
+    <custom-style>
+        <style is="custom-style" include="demo-pages-shared-styles">
+        </style>
+    </custom-style>
+</head>
+
+<body>
+    <div class="vertical-section-container centered">
+        <h3>tangy-photo-capture demo</h3>
+        <demo-snippet>
+            <template>
+                <tangy-photo-capture name="test-photo" max-size-in-kb='128'></tangy-photo-capture>
+            </template>
+        </demo-snippet>
+    </div>
+</body>
+
+</html>

--- a/input/tangy-photo-capture.js
+++ b/input/tangy-photo-capture.js
@@ -78,7 +78,7 @@ export class TangyPhotoCapture extends PolymerElement {
       },
       maxSizeInKb: {
         type: Number,
-        value: '256',
+        value: 256,
         reflectToAttribute: true
       },
       hintText: {
@@ -224,7 +224,7 @@ export class TangyPhotoCapture extends PolymerElement {
       imageWidth: imageWidth.max,
       imageHeight: imageHeight.max
     })
-    var ImageReducer = new ImageBlobReduce()
+    const ImageReducer = new ImageBlobReduce()
     // Forces the output to be a JPG of .8 quality
     ImageReducer._create_blob = function (env) {
       return this.pica.toBlob(env.out_canvas, 'image/jpeg', 0.8)
@@ -262,32 +262,6 @@ export class TangyPhotoCapture extends PolymerElement {
     
     this.shadowRoot.querySelector('#capture-button').setAttribute('disabled', '')
     this.shadowRoot.querySelector('#accept-button').setAttribute('disabled', '')
-  }
-
-  downscaleImage(dataUrl, newWidth, imageType, imageArguments) {
-    var image, oldWidth, oldHeight, newHeight, canvas, ctx, newDataUrl;
-
-    // Provide default values
-    imageType = imageType || "image/jpeg";
-    imageArguments = imageArguments || 0.7;
-
-    // Create a temporary image so that we can compute the height of the downscaled image.
-    image = new Image();
-    image.src = dataUrl;
-    oldWidth = image.width;
-    oldHeight = image.height;
-    newHeight = Math.floor(oldHeight / oldWidth * newWidth)
-
-    // Create a temporary canvas to draw the downscaled image on.
-    canvas = document.createElement("canvas");
-    canvas.width = newWidth;
-    canvas.height = newHeight;
-
-    // Draw the downscaled image on the canvas and return the new data URL.
-    ctx = canvas.getContext("2d");
-    ctx.drawImage(image, 0, 0, newWidth, newHeight);
-    newDataUrl = canvas.toDataURL(imageType, imageArguments);
-    return newDataUrl;
   }
 
   onDiscrepancyChange(value) {

--- a/package.json
+++ b/package.json
@@ -27,6 +27,7 @@
     "devtools-detect": "^3.0.0",
     "dr-niels-sortable-list": "git://github.com/DrNiels/sortable-list.git#master",
     "ethiopian-date": "0.0.6",
+    "image-blob-reduce": "^2.2.3",
     "lit-element": "^2.3.1",
     "moment": "^2.24.0",
     "redux": "^4.0.0",

--- a/test/tangy-photo-capture_test.html
+++ b/test/tangy-photo-capture_test.html
@@ -1,0 +1,62 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width, minimum-scale=1, initial-scale=1, user-scalable=yes">
+    <title>tangy-photo-capture test</title>
+    <script src="../node_modules/@webcomponents/webcomponentsjs/webcomponents-loader.js"></script>
+    <script src="../node_modules/redux/dist/redux.js"></script>
+    <script src="../node_modules/wct-browser-legacy/browser.js"></script>
+  </head>
+  <body>
+     
+    <test-fixture id="TangyPhotoCaptureFixture">
+      <template>
+        <tangy-photo-capture 
+          name="test_image" 
+          label="
+            <t-lang en>English label</t-lang>
+            <t-lang fr>French label</t-lang>
+          "
+          error-text="
+            <t-lang en>English error-text</t-lang>
+            <t-lang fr>French error-text</t-lang>
+          "
+          hint-text="
+            <t-lang en>English hint-text</t-lang>
+            <t-lang fr>French hint-text</t-lang>
+          "
+          question-number="1."
+          allow-blank
+          required
+        ></tangy-photo-capture>
+      </template>
+    </test-fixture>
+
+    <script type="module">
+      import '../input/tangy-photo-capture.js'
+      suite('tangy-photo-capture', () => {
+
+        [
+          "#image", 
+          "#accept-button", 
+          "#clear-button", 
+          "#capture-button"
+        ].forEach( elementId => {
+          test(`Should load ${elementId}`, function() {
+            const element = fixture('TangyPhotoCaptureFixture');
+            assert.isNotNull(element.shadowRoot.querySelector(elementId))
+          })
+        })
+
+        test('should resume image if value exists', () => {
+          const element = fixture('TangyPhotoCaptureFixture');
+          element.value = "data:image/jpeg;base64,/9j/4AAQSkZJRgABAQAAAQABAAD/2wBDAAYEBQYFBAYGBQYHBwYIChAKCgkJChQODwwQFxQYGBcUFhYaHSUfGhsjHBYWICwgIyYnKSopGR8tMC0oMCUoKSj/2wBDAQcHBwoIChMKChMoGhYaKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCj/wAARCAAmADIDASIAAhEBAxEB/8QAGwAAAgMBAQEAAAAAAAAAAAAAAAYEBQcCAwH/xAAyEAACAQMDAgQEAwkAAAAAAAABAgMEBREAEiEGMQcTQVEiYXGxMnKBFSNSkaHB0eHw/8QAGgEAAgMBAQAAAAAAAAAAAAAABAUAAwYBAv/EACQRAAEEAQQBBQEAAAAAAAAAAAEAAgMRBAUSITFBBhMUI1GB/9oADAMBAAIRAxEAPwBXslsqFgVaja+RlWUjt8x6f31cLbSOw50yU1ilpblSRzhxDUwllYMCilcZGccd/fTHTdPQzkIk8TP/AAmT/hrNtyHXZRro6WeCiOPw6U+uLw9rghpbYY3uNQ21VBBKD6e5OAP11rd1ttPTxzgSxiRFYcHODj76xHwv6aa83SrrKx/OaB+AAdxfvu+ePbTnS4xlyUTwEDlyexGXVa+yt1d0tGlbf6YVNAOZAjK7KPmR2+2tTtlE1zstHco1MVvwkzsy87WxjI+pxql6sNeLNJReZHIuHV2khzJgAcd8Y5Pcar+ir7W3Lw8hjk8xIqVzSrtzidVAbefy5251PUOCI2h8fk0uYE5k4cr17nVI7JFUusanCjC8D09NGl4ynJyTo1mPjP8A1MtwTr0k1RWzWungXbSXGSYTNI3IjU4DBQeeQffTNc5Lx0vVXpbbVUMcEEURV27/ABMBlgfTGcfPXn4OSq15tML026aktoiWbaQsbsWdx+u7GdN3i1cFTp2rimpaV3JXDPKoLgZPAJycHHHfnto6OHdCT5B4FKsuG8D9We3m7SU1PLM9Kk1SKjZJhThvhBz341n/AETc5qfqa+wyRR08Tt5sUKJsC5yePv8Az1EvfVt1nqJmiDUsdQ251iGMeg57++qS2XCKWpmMvmRzs25XyQ2R2O73+utFpWmS4v2ucOukrzMtkv1tH9TLc57rGs5neKaaZDHEkabWJcgctzkeufkdTZUhtlgo6Gj+Cnp1MQy3f1yT7kjSB1DXztUU/nVJeVXDgxpswe2Tt9efvr3ourJ6ciO4wiqiU5YlcMCPUeh/XVms4kuXtezoeFMSdkZIPlXbud7fXRqGKyGQb0cbG+IZ44OjSHZXaY2Ey+FvWNqsl2kqas3WbgcBY27duMgajeJvi9J1Dc0pLdHP5avhTVJGNufkv+dGjVrY2/J21wF4s+3az+pucmyRZyFcnP7mMAahQ14eUrlwDnJ2gk/10aNPIHG6S+UCrXcs3nZy5ynY7MH76rprjJCoY/hY4476NGipeRyqou13+0yeS7Z/L/vRo0aWI9f/2Q=="
+          assert(element.shadowRoot.querySelector("img").getAttribute("src") == element.value)
+        })
+
+      })
+    </script>
+
+  </body>
+</html>


### PR DESCRIPTION
Updated the photo capture component. It looks like this:
<tangy-photo-capture name="test-photo" max-size-in-kb='10'></tangy-photo-capture>

It saves the data in jpeg format with a base64 encoding. 

It attemps to take the picture with the highest possible quality and then resizes it with best practice resizing algorithms (using the built-in canvas resizer is poor quality). By default it tries to keep the size below 256kb, but this can be changed to any arbitrary size using the max-size-in-kb attribute.

There are a few tests, but they are not great.


