### PR TITLE
Add support for skipping items by defining cycle sequences 

### DIFF
--- a/tangy-form-reducer.js
+++ b/tangy-form-reducer.js
@@ -32,6 +32,7 @@ const tangyFormReducer = function (state = initialState, action) {
         }
         currentSequence = cycleSequencesArray[currentCycleIndex].split(',');
       }
+      currentSequence = currentSequence.map(sequence => parseInt(sequence))
       newState = Object.assign({}, action.response)
       // Ensure that the only items we have in the response are those that are in the DOM but maintain state of the existing items in the response.
       newState.items = action.itemsInDom.map((itemInDom, index) => {
@@ -40,11 +41,23 @@ const tangyFormReducer = function (state = initialState, action) {
         return result ? {...merged}: {...itemInDom}
         }
       )
-      let tempItems = []
-      currentSequence.forEach((e)=>tempItems.push(newState.items[e-1]))
-      newState.items = tempItems
+      const itemsInSequence = currentSequence.map((sequenceNumber) => newState.items[sequenceNumber - 1])
+      const itemsNotInSequence = newState
+        .items
+        .filter((item, index) => !currentSequence.includes(index+1))
+        .map((item) => {
+          return {
+            ...item,
+            disabled: true
+          }
+        })
+      // Shove disabled items not in sequence after the first entry in the items array because we can't have disabled items at the beginning or end.
+      newState.items = [
+        itemsInSequence.shift(),
+        ...itemsNotInSequence,
+        ...itemsInSequence
+      ]
       newState.items[0]['firstOpenTime']= newState.items[0]['firstOpenTime'] ? newState.items[0]['firstOpenTime'] : Date.now()
-
       firstNotDisabled = newState.items.findIndex(item => !item.disabled)
       newState.items[firstNotDisabled].hideBackButton = true
       const indexOfSummaryItem = newState.items.findIndex(item => item.summary === true)

--- a/test/tangy-form_test.html
+++ b/test/tangy-form_test.html
@@ -277,13 +277,31 @@
     <test-fixture id="SkipSecondItem">
       <template>
         <tangy-form id="my-form" title="My Form" on-change="skip('item2')">
-          <tangy-form-item id="item1">
+          <tangy-form-item id="item1" title="1">
             <tangy-input name="input1" label="What is your last name?"></tangy-input>
           </tangy-form-item>
-          <tangy-form-item id="item2">
+          <tangy-form-item id="item2" title="2">
             <tangy-input name="input2" label="What is your last name?"></tangy-input>
           </tangy-form-item>
-          <tangy-form-item id="item3">
+          <tangy-form-item id="item3" title="3">
+            <tangy-input name="input3" label="What is your last name?"></tangy-input>
+          </tangy-form-item>
+        </tangy-form>
+      </template>
+    </test-fixture>
+
+    <test-fixture id="SkipSecondItemCycleSequences">
+      <template>
+        <tangy-form id="SkipSecondItemCycleSequences" title="My Form" cycle-sequences="1,3
+        1,3
+        1,3">
+          <tangy-form-item id="item1" title="1">
+            <tangy-input name="input1" label="What is your last name?"></tangy-input>
+          </tangy-form-item>
+          <tangy-form-item id="item2" title="2">
+            <tangy-input name="input2" label="What is your last name?"></tangy-input>
+          </tangy-form-item>
+          <tangy-form-item id="item3" title="3">
             <tangy-input name="input3" label="What is your last name?"></tangy-input>
           </tangy-form-item>
         </tangy-form>
@@ -311,8 +329,19 @@
 
       suite('tangy-form', () => {
 
-        test('should skip second item', () => {
+        test('should skip second item due to skip logic', () => {
           const element = fixture('SkipSecondItem');
+          element.newResponse()
+          element.querySelector('#item1').shadowRoot.querySelector('dom-if').render()
+          element.querySelector('#item1').shadowRoot.querySelector('#next').click()
+          // If second item wasn't skipped, the following would fail.
+          element.querySelector('#item3').shadowRoot.querySelector('dom-if').render()
+          element.querySelector('#item3').shadowRoot.querySelector('#complete').click()
+        })
+
+        test('should skip second item due to cycle-sequences', () => {
+          const element = fixture('SkipSecondItemCycleSequences');
+          debugger
           element.newResponse()
           element.querySelector('#item1').shadowRoot.querySelector('dom-if').render()
           element.querySelector('#item1').shadowRoot.querySelector('#next').click()


### PR DESCRIPTION
This PR add support for skipping items by defining cycle sequences that don't cover all items in a form. Here's the form from the test in this PR, note how the cycle sequences defined should never allow item2 to appear.

```
        <tangy-form id="SkipSecondItemCycleSequences" title="My Form" cycle-sequences="1,3
        1,3
        1,3">
          <tangy-form-item id="item1" title="1">
            <tangy-input name="input1" label="What is your last name?"></tangy-input>
          </tangy-form-item>
          <tangy-form-item id="item2" title="2">
            <tangy-input name="input2" label="What is your last name?"></tangy-input>
          </tangy-form-item>
          <tangy-form-item id="item3" title="3">
            <tangy-input name="input3" label="What is your last name?"></tangy-input>
          </tangy-form-item>
        </tangy-form>
```