### PR TITLE
Render tangy templates in submitted form responses

### DIFF
--- a/tangy-form-item.js
+++ b/tangy-form-item.js
@@ -592,6 +592,12 @@ export class TangyFormItem extends PolymerElement {
     // Open it, but only if empty because we might be stuck.
     if (open === true && this.innerHTML === '') {
       this.openWithContent(this.template)
+      // Render tangy-template's.
+      this.querySelectorAll('tangy-template').forEach(templateEl => {
+        if (templateEl.shadowRoot) {
+          templateEl.$.container.innerHTML = this.eval('`' + templateEl.template + '`', 'tangy-template', templateEl.getAttribute('name'), true)
+        }
+      })
     }
   }
 

--- a/tangy-template.js
+++ b/tangy-template.js
@@ -4,8 +4,9 @@ import './style/tangy-common-styles.js'
 import './style/tangy-element-styles.js'
 
     /**
-     * `tangy-radio-button`
+     * `tangy-template`
      *
+     * This element does not have the separation of concerns you might expect from this component. The life cycle of the element is handled by the `tangy-form-item` element.
      *
      * @customElement
      * @polymer

--- a/test/tangy-template_test.html
+++ b/test/tangy-template_test.html
@@ -88,6 +88,21 @@
           form.querySelector('#item1').shadowRoot.querySelector('dom-if').render();
           assert.equal(form.querySelector('#item1').querySelector('tangy-template').$.container.innerText, 'Test')
         })
+
+        test('should have dynamic templated output when reviewed in a submitted form', function () {
+          const form = fixture('TangyTemplateFixture');
+          form.newResponse()
+          form.querySelector('#item1').shadowRoot.querySelector('dom-if').render()
+          form.querySelector('#item1').querySelector('[name="input1"]').value = 'foo'
+          form.querySelector('#item1').shadowRoot.querySelector('#next').click()
+          form.querySelector('#item2').shadowRoot.querySelector('dom-if').render()
+          form.querySelector('#item2').shadowRoot.querySelector('#complete').click()
+          form.querySelector('#item2').shadowRoot.querySelector('dom-if').render();
+          form.querySelector('#item2').shadowRoot.querySelector('#open').click()
+          form.querySelector('#item2').shadowRoot.querySelector('dom-if').render();
+          assert.equal(form.querySelector('#item2').querySelector('tangy-template').$.container.innerText, 'Output foo')
+       })
+
         test('should have templated output from advanced condition', function () {
           const form = fixture('TangyTemplateAdvanced');
           form.newResponse()

--- a/test/tangy-template_test.html
+++ b/test/tangy-template_test.html
@@ -22,6 +22,17 @@
         </tangy-form>
       </template>
     </test-fixture>
+    
+    <test-fixture id="TangyTemplateSimple">
+      <template>
+        <tangy-form id="form1">
+          <tangy-form-item id="item1">
+            <tangy-template name="foo">Test</tangy-template>
+          </tangy-form-item>
+        </tangy-form>
+      </template>
+    </test-fixture>
+
 
     <test-fixture id="TangyTemplateAdvanced">
       <template>
@@ -55,6 +66,7 @@
     </test-fixture>
 
     <script type="module">
+      // tangy-template imported by tangy-form.
       import '../tangy-form.js'
       import '../input/tangy-input.js'
       suite('tangy-template', () => {
@@ -65,6 +77,16 @@
           form.querySelector('#item1').querySelector('[name="input1"]').value = 'foo'
           form.querySelector('#item1').shadowRoot.querySelector('#next').click()
           assert.equal(form.querySelector('#item2').querySelector('tangy-template').$.container.innerText, 'Output foo')
+        })
+        test('should have templated output when reviewed in a submitted form', function () {
+          const form = fixture('TangyTemplateSimple');
+          form.newResponse()
+          form.querySelector('#item1').shadowRoot.querySelector('dom-if').render()
+          form.querySelector('#item1').shadowRoot.querySelector('#complete').click()
+          form.querySelector('#item1').shadowRoot.querySelector('dom-if').render();
+          form.querySelector('#item1').shadowRoot.querySelector('#open').click()
+          form.querySelector('#item1').shadowRoot.querySelector('dom-if').render();
+          assert.equal(form.querySelector('#item1').querySelector('tangy-template').$.container.innerText, 'Test')
         })
         test('should have templated output from advanced condition', function () {
           const form = fixture('TangyTemplateAdvanced');


### PR DESCRIPTION
Currently, any markup (dynamic or static) in a `<tangy-template>` will not appear when reviewing a submitted form response. This fixes that.