### PR TITLE
Dynamically evaluate directives on tangy-template on complete responses

### DIFF
--- a/test/tangy-template_test.html
+++ b/test/tangy-template_test.html
@@ -65,6 +65,20 @@
       </template>
     </test-fixture>
 
+    <test-fixture id="TangyTemplateDirectiveFixture">
+      <template>
+        <tangy-form id="form1">
+          <tangy-form-item id="item1">
+            <tangy-input name="input1" label="input1"></tangy-input>
+          </tangy-form-item>
+          <tangy-form-item id="item2">
+            <tangy-template name="template1" dont-skip-if="getValue('input1') === '1'">template1</tangy-template>
+            <tangy-template name="template2" dont-skip-if="getValue('input1') === '2'">template2</tangy-template>
+          </tangy-form-item>
+        </tangy-form>
+      </template>
+    </test-fixture>
+
     <script type="module">
       // tangy-template imported by tangy-form.
       import '../tangy-form.js'
@@ -88,7 +102,6 @@
           form.querySelector('#item1').shadowRoot.querySelector('dom-if').render();
           assert.equal(form.querySelector('#item1').querySelector('tangy-template').$.container.innerText, 'Test')
         })
-
         test('should have dynamic templated output when reviewed in a submitted form', function () {
           const form = fixture('TangyTemplateFixture');
           form.newResponse()
@@ -102,7 +115,6 @@
           form.querySelector('#item2').shadowRoot.querySelector('dom-if').render();
           assert.equal(form.querySelector('#item2').querySelector('tangy-template').$.container.innerText, 'Output foo')
        })
-
         test('should have templated output from advanced condition', function () {
           const form = fixture('TangyTemplateAdvanced');
           form.newResponse()
@@ -119,6 +131,20 @@
           form.newResponse()
           form.querySelector('#item1').shadowRoot.querySelector('dom-if').render()
           assert.equal(form.querySelector('#item1').querySelector('tangy-template').$.container.innerText, 'bar')
+        })
+        test('should have directive evaluated on a submitted form', function () {
+          const form = fixture('TangyTemplateDirectiveFixture');
+          form.newResponse()
+          form.querySelector('#item1').shadowRoot.querySelector('dom-if').render()
+          form.querySelector('#item1').querySelector('[name="input1"]').value = '2'
+          form.querySelector('#item1').shadowRoot.querySelector('#next').click()
+          form.querySelector('#item2').shadowRoot.querySelector('dom-if').render()
+          form.querySelector('#item2').shadowRoot.querySelector('#complete').click()
+          form.querySelector('#item2').shadowRoot.querySelector('dom-if').render();
+          form.querySelector('#item2').shadowRoot.querySelector('#open').click()
+          form.querySelector('#item2').shadowRoot.querySelector('dom-if').render();
+          assert.equal(form.querySelector('#item2').querySelector('[name="template1"]').hasAttribute('skipped'), true)
+          assert.equal(form.querySelector('#item2').querySelector('[name="template2"]').hasAttribute('skipped'), false)
         })
       })
     </script>


### PR DESCRIPTION
When viewing a completed form response, all tangy-templates now appear regardless of any previously evaluated directive because state like `skipped` has not been saved in form responses. This PR makes tangy-template even more dynamic by evaluating directives on tangy-template even when in a completed form response.

## Trade offs
An alternative approach would be to save the tangy-template's state in the form response like we do with everything else. The downside of this approach is tangy-templates can get quite large can balloon form response sizes. For consistency sake though and predictable behavior, saving the state would be a win. We should consider a new tangy-template-2 (or other name) element that would save state so that form developers can choose which trade-off makes sense for which tangy template. 