### PR TITLE
Add getValueAsMoment helper function

### DIFF
--- a/tangy-form-item-callback-helpers.js
+++ b/tangy-form-item-callback-helpers.js
@@ -1,5 +1,5 @@
-import moment from 'moment'
-import * as ethiopianDate from 'ethiopian-date/index.js'
+import { TangyPartialDate } from '../tangy-partial-date.js'
+import { TangyEthiopianDate } from '../tangy-ethio-date.js'
 
 export class TangyFormItemHelpers {
 
@@ -81,78 +81,19 @@ export class TangyFormItemHelpers {
         }
       })
     }
-    if(foundInput && typeof foundInput.value === 'object') {
-      let values = []
-      foundInput.value.forEach(subInput => {
-        if (subInput.value) {
-          values.push(subInput.name)
-        }
-      })
-      value = values
-    } else if (foundInput && foundInput.value !== undefined) {
-      value = foundInput.value
-    }
     if (foundInput && foundInput.tagName === 'TANGY-PARTIAL-DATE') {
-      //var partial_input = new TangyPartialDate() <--- can we do this instead
-      value = _transformValueToMoment(value)
+      var partial_input = new TangyPartialDate()
+      value = partial_input.getValueAsMoment()
     }
     if (foundInput && foundInput.tagName === 'TANGY-ETHIOPIAN-DATE') {
-      //var partial_input = new TangyEthiopianDate() <--- can we do this instead
-      value = _transformValueToMomentEthiopian(value)
+      var partial_input = new TangyEthiopianDate()
+      value = partial_input.getValueAsMoment()
     } else {
       console.warn(`${foundInput.name} is a ${foundInput.tagName}, not a partial date`)
     }
-    if (!value) {
-      value = ''
-    }
-    // console.log("input name: " + name + " foundInput: " + foundInput + " typeof value " + typeof value + " value: " + value)
     return value
   }
-
-  _transformValueToMoment(value) {
-    const [year, month, day] = value.split('-')
-    let date = null
-    if (year === '9999' || year === '') {
-      // Need at least a year to calculate.
-      return null
-    } else if (month === '99' || month === '') {
-      // We don't have a month, just have a year to go off of.
-      date = moment(year, 'YYYY')
-    } else if (day === '99' || day === '') {
-      // We don't have a day, go off of year and month.
-      date = moment(`${year}-${month}`, 'YYYY-MM')
-    } else {
-      date = moment(`${year}-${month}-${day}`, 'YYYY-MM-DD')
-    }
-    return date
-  }
-
-  _transformValueToMomentEthiopian(value) {
-    var [year_part, month_part, day_part] = value.split('-');
-
-    let date = null
-    if (year_part === '9999' || year_part === '') {
-      // Need at least a year to calculate.
-      return null
-    }
-    if (month_part === '99' || month_part === '') {
-      // We don't have a month, just have a year to go off of.
-      month_part = '01'
-    }
-    if (day_part === '99' || day_part === '') {
-      // We don't have a day, go off of year and month.
-      day_part = '01'
-    }
-
-    const greg_date = ethiopianDate.toGregorian(parseInt(year_part), parseInt(month_part), parseInt(day_part));
-    const year = greg_date[0];
-    const month = greg_date[1];
-    const day = greg_date[2];
-    date = moment(`${year}-${month}-${day}`, 'YYYY-MM-DD')
-
-    return date
-  }
-
+ 
   isChecked(name) {
     return (this.inputs.find(input => name === input.name).value === 'on') ? true : false
   }

--- a/tangy-form-item-callback-helpers.js
+++ b/tangy-form-item-callback-helpers.js
@@ -1,3 +1,6 @@
+import moment from 'moment'
+import * as ethiopianDate from 'ethiopian-date/index.js'
+
 export class TangyFormItemHelpers {
 
   constructor(element) {
@@ -56,6 +59,98 @@ export class TangyFormItemHelpers {
     }
     // console.log("input name: " + name + " foundInput: " + foundInput + " typeof value " + typeof value + " value: " + value)
     return value
+  }
+
+  getValueAsMoment(name) {
+    let value = ''
+    let foundInput = undefined
+    // Look in the shadow DOM.
+    this.inputs.forEach(input => {
+      if (input.name === name) {
+        foundInput = input
+      }
+    })
+    // Look in the store.
+    if (!foundInput) {
+      let state = this.element.store.getState()
+      let inputs = []
+      state.items.forEach(item => inputs = [...inputs, ...item.inputs])
+      foundInput = inputs.find(input => {
+        if (input.name === name) {
+          return input
+        }
+      })
+    }
+    if(foundInput && typeof foundInput.value === 'object') {
+      let values = []
+      foundInput.value.forEach(subInput => {
+        if (subInput.value) {
+          values.push(subInput.name)
+        }
+      })
+      value = values
+    } else if (foundInput && foundInput.value !== undefined) {
+      value = foundInput.value
+    }
+    if (foundInput && foundInput.tagName === 'TANGY-PARTIAL-DATE') {
+      //var partial_input = new TangyPartialDate() <--- can we do this instead
+      value = _transformValueToMoment(value)
+    }
+    if (foundInput && foundInput.tagName === 'TANGY-ETHIOPIAN-DATE') {
+      //var partial_input = new TangyEthiopianDate() <--- can we do this instead
+      value = _transformValueToMomentEthiopian(value)
+    } else {
+      console.warn(`${foundInput.name} is a ${foundInput.tagName}, not a partial date`)
+    }
+    if (!value) {
+      value = ''
+    }
+    // console.log("input name: " + name + " foundInput: " + foundInput + " typeof value " + typeof value + " value: " + value)
+    return value
+  }
+
+  _transformValueToMoment(value) {
+    const [year, month, day] = value.split('-')
+    let date = null
+    if (year === '9999' || year === '') {
+      // Need at least a year to calculate.
+      return null
+    } else if (month === '99' || month === '') {
+      // We don't have a month, just have a year to go off of.
+      date = moment(year, 'YYYY')
+    } else if (day === '99' || day === '') {
+      // We don't have a day, go off of year and month.
+      date = moment(`${year}-${month}`, 'YYYY-MM')
+    } else {
+      date = moment(`${year}-${month}-${day}`, 'YYYY-MM-DD')
+    }
+    return date
+  }
+
+  _transformValueToMomentEthiopian(value) {
+    var [year_part, month_part, day_part] = value.split('-');
+
+    let date = null
+    if (year_part === '9999' || year_part === '') {
+      // Need at least a year to calculate.
+      return null
+    }
+    if (month_part === '99' || month_part === '') {
+      // We don't have a month, just have a year to go off of.
+      month_part = '01'
+    }
+    if (day_part === '99' || day_part === '') {
+      // We don't have a day, go off of year and month.
+      day_part = '01'
+    }
+
+    const greg_date = ethiopianDate.toGregorian(parseInt(year_part), parseInt(month_part), parseInt(day_part));
+    const year = greg_date[0];
+    const month = greg_date[1];
+    const day = greg_date[2];
+    date = moment(`${year}-${month}-${day}`, 'YYYY-MM-DD')
+
+    return date
   }
 
   isChecked(name) {

--- a/tangy-form-item.js
+++ b/tangy-form-item.js
@@ -587,7 +587,7 @@ export class TangyFormItem extends PolymerElement {
     // Declare namespaces for helper functions for the eval context in form.on-change.
     // We have to do this because bundlers modify the names of things that are imported
     // but do not update the evaled code because it knows not of it.
-    let {getValue, inputHide, inputShow, skip, unskip, inputDisable, inputEnable, itemHide, itemShow, itemDisable, itemEnable, isChecked, notChecked, itemsPerMinute, numberOfItemsAttempted, numberOfCorrectItems, numberOfIncorrectItems, gridAutoStopped, hideInputsUponThreshhold, goTo, goToEnd} = this.exposeHelperFunctions()
+    let {getValue, getValueAsMoment, inputHide, inputShow, skip, unskip, inputDisable, inputEnable, itemHide, itemShow, itemDisable, itemEnable, isChecked, notChecked, itemsPerMinute, numberOfItemsAttempted, numberOfCorrectItems, numberOfIncorrectItems, gridAutoStopped, hideInputsUponThreshhold, goTo, goToEnd} = this.exposeHelperFunctions()
     if (this.hasAttribute("incorrect-threshold")) {
       hideInputsUponThreshhold(this)
     }
@@ -611,6 +611,7 @@ export class TangyFormItem extends PolymerElement {
   exposeHelperFunctions() {
     let helpers = new TangyFormItemHelpers(this)
     let getValue = (name) => helpers.getValue(name)
+    let getValueAsMoment = (name) => helpers.getValueAsMoment(name)
     let skip = (name) => helpers.skip(name)
     let unskip = (name) => helpers.unskip(name)
     let inputHide = (name) => helpers.inputHide(name)
@@ -632,7 +633,7 @@ export class TangyFormItem extends PolymerElement {
     let hideInputsUponThreshhold = (input) => helpers.hideInputsUponThreshhold(input)
     let goTo = (itemId, skipValidation = false) => helpers.goTo(itemId, skipValidation)
     let goToEnd = (skipValidation = false) => helpers.goToEnd(skipValidation)
-    return {getValue, inputHide, inputShow, skip, unskip, inputDisable, inputEnable, itemHide, itemShow, itemDisable, itemEnable, isChecked, notChecked, itemsPerMinute, numberOfItemsAttempted, numberOfCorrectItems, numberOfIncorrectItems, gridAutoStopped, hideInputsUponThreshhold, goTo, goToEnd};
+    return {getValue, getValueAsMoment, inputHide, inputShow, skip, unskip, inputDisable, inputEnable, itemHide, itemShow, itemDisable, itemEnable, isChecked, notChecked, itemsPerMinute, numberOfItemsAttempted, numberOfCorrectItems, numberOfIncorrectItems, gridAutoStopped, hideInputsUponThreshhold, goTo, goToEnd};
   }
 
   onOpenButtonPress() {
@@ -736,7 +737,7 @@ export class TangyFormItem extends PolymerElement {
     let firstInputWithIssue = ''
     for (let input of inputEls) {
       if (!input.hidden && !input.skipped) {
-        let {getValue, inputHide, inputShow, skip, unskip, inputDisable, inputEnable, itemHide, itemShow, itemDisable, itemEnable, isChecked, notChecked, itemsPerMinute, numberOfItemsAttempted, numberOfCorrectItems, numberOfIncorrectItems, gridAutoStopped, hideInputsUponThreshhold} = this.exposeHelperFunctions();
+        let {getValue, getValueAsMoment, inputHide, inputShow, skip, unskip, inputDisable, inputEnable, itemHide, itemShow, itemDisable, itemEnable, isChecked, notChecked, itemsPerMinute, numberOfItemsAttempted, numberOfCorrectItems, numberOfIncorrectItems, gridAutoStopped, hideInputsUponThreshhold} = this.exposeHelperFunctions();
         if ((input.validate && !input.validate()) || (input.hasAttribute('valid-if') && !eval(input.getAttribute('valid-if')))) {
           input.invalid = true
           if (!firstInputWithIssue) firstInputWithIssue = input.name

--- a/tangy-form-reducer.js
+++ b/tangy-form-reducer.js
@@ -141,7 +141,6 @@ const tangyFormReducer = function (state = initialState, action) {
             props.open = true
           }
           return Object.assign({}, item, props)
-         return item
         })
       })
 


### PR DESCRIPTION
New helper function for validation of inputs across form sections.

The function `getValueAsMoment` is available in the classes `TangyPartialDate` and `TangyEthiopianDate`. The function turns any date value including unkown values into useful momentjs objects, e.g.:

```
inputs.SOME_DATE.value = "2022-03-22"
var _moment = inputs.SOME_DATE.getValueAsMoment()
_moment.isValid()
> true
_moment.format('DD/MM/YYYY')
> 22/03/2022
```

```
// with unknown day
inputs.SOME_DATE.value = "2022-03-99"
var _moment = inputs.SOME_DATE.getValueAsMoment()
_moment.isValid()
> true
_moment.format('MM/YYYY')
> 03/2022
```

**HOWEVER** this function is only available if you are inside a `tangy-form` on-submit or on-change logic, or in the `tangy-form-item` in which the variable is defined.  So this does not currently work:

```
input.SOME_DATE.getValueAsMoment() < input.OTHER_DATE.getValueAsMoment()
```

This addition will make it so you can use the following logic to check dates against each other anywhere in a form, e.g.:

```
getValueAsMoment('SOME_DATE') < getValueAsMoment('OTHER_DATE')
```
 