### PR TITLE
[#338] Allow items behind card-actions to be tapped.

### DIFF
--- a/style/tangy-element-styles.js
+++ b/style/tangy-element-styles.js
@@ -55,7 +55,7 @@ $_documentStyleContainer.innerHTML = `<dom-module id="tangy-element-styles">
       }
       .flex-container > #qnum-content {
         width: 100%;
-        padding-right: 2em;
+        /* padding-right: 2em; */
       }
       #qnum-number > label {
         margin-right: 0.5rem;

--- a/tangy-form-item.js
+++ b/tangy-form-item.js
@@ -112,6 +112,8 @@ export class TangyFormItem extends PolymerElement {
           right: 0px;
           padding: 0px;
           margin: 0px;
+          pointer-events: none;
+          border-top: none;
         }
         :host([fullscreen-enabled]) paper-button {
           background-color: var(--fullscreen-nav--background-color, white);
@@ -123,6 +125,7 @@ export class TangyFormItem extends PolymerElement {
           color: var(--fullscreen-nav--color, grey);
           height: var(--fullscreen-nav--height);
           width: var(--fullscreen-nav--width);
+          pointer-events: auto;
  
         }
         /* Buttons when nav aligned at the top */
@@ -178,6 +181,8 @@ export class TangyFormItem extends PolymerElement {
         }
         :host([fullscreen-enabled]) .card-content {
           padding-top: 0px;
+          padding-left: var(--fullscreen-nav--width);
+          padding-right: var(--fullscreen-nav--width);
         }
         :host([fullscreen-enabled]) .card-actions .check-mark {
           display: none;


### PR DESCRIPTION
I decided to fix this by setting the pointer-events of the element containing the next/back buttons to none, so the taps can be registered by whatever's behind it. Then I set the pointer-events for the next/back buttons themselves back to auto so that they can be tapped. I made a couple of changes to the content area of the page to try and ensure that the fixed-position navigational buttons don't visually overlap anything in the content area.