### PR TITLE
fix(audio-playback): update playback functionality

### DIFF
--- a/input/tangy-audio-playback.js
+++ b/input/tangy-audio-playback.js
@@ -37,7 +37,7 @@ export class TangyAudioPlayback extends TangyInputBase {
       hintText: {
         type: String,
         value: "",
-        reflectToAttribute: true,
+        observer: 'onHintTextChange',
       },
       label: {
         type: String,
@@ -92,7 +92,7 @@ export class TangyAudioPlayback extends TangyInputBase {
       },
       controls: {
         type: Boolean,
-        value: false,
+        value: true,
         reflectToAttribute: true,
       },
     };
@@ -101,15 +101,16 @@ export class TangyAudioPlayback extends TangyInputBase {
   constructor() {
     super();
     this.src = "";
-    this.controls = true;
   }
 
-  reflect(){
-    this.shadowRoot.querySelector('#qnum-number').innerHTML = this.hasAttribute('question-number')
-    ? `<label>${this.getAttribute('question-number')}</label>`
-    : ''
-    this.shadowRoot.querySelector('#hintText').innerHTML = this.hintText
-    this.shadowRoot.querySelector('#label').innerHTML = this.label
+  reflect() {
+    this.shadowRoot.querySelector("#qnum-number").innerHTML = this.hasAttribute(
+      "question-number"
+    )
+      ? `<label>${this.getAttribute("question-number")}</label>`
+      : "";
+    this.shadowRoot.querySelector("#hintText").innerHTML = this.hintText;
+    this.shadowRoot.querySelector("#label").innerHTML = this.label;
   }
 }
 


### PR DESCRIPTION
fix(audio-playback): update controls default value and add observer for hintText

Updated the `controls` property default value to `true` and added an observer for the `hintText` property in the `TangyAudioPlayback` class. This ensures that the controls are enabled by default and any changes to the hint text are properly observed and handled.

body (optional)

Refs Tangerine-Community/tangy-form#418