### PR TITLE
feat(input): add autoStopMode option to timed and untimed grids

### DIFF
--- a/input/tangy-timed.js
+++ b/input/tangy-timed.js
@@ -264,6 +264,11 @@ class TangyTimed extends TangyInputBase {
         value: undefined,
         reflectToAttribute: true
       },
+      autoStopMode: {
+        type: String,
+        value: 'first', // 'first' or 'consecutive'
+        reflectToAttribute: true
+      },
       gridVarItemAtTime: {
         type: Number,
         reflectToAttribute: true,
@@ -612,14 +617,30 @@ class TangyTimed extends TangyInputBase {
   }
   shouldGridAutoStop() {
     const tangyToggleButtons = [].slice.call(this.shadowRoot.querySelectorAll('tangy-toggle-button'))
-    const firstXButtons = tangyToggleButtons.slice(0, this.autoStop)
-    let foundAnUnpressedButton = false
-    for (let button of firstXButtons) {
-      if (!button.pressed) {
-        foundAnUnpressedButton = true
+    
+    if (this.autoStopMode === 'first') {
+      const firstXButtons = tangyToggleButtons.slice(0, this.autoStop)
+      let foundAnUnpressedButton = false
+      for (let button of firstXButtons) {
+        if (!button.pressed) {
+          foundAnUnpressedButton = true
+        }
       }
+      return foundAnUnpressedButton ? false : true
+    } else if (this.autoStopMode === 'consecutive') {
+      let consecutiveCount = 0
+      for (let button of tangyToggleButtons) {
+        if (button.pressed) {
+          consecutiveCount++
+          if (consecutiveCount >= this.autoStop) {
+            return true
+          }
+        } else {
+          consecutiveCount = 0
+        }
+      }
+      return false
     }
-    return foundAnUnpressedButton ? false : true
   }
   stopGrid() {
 

--- a/input/tangy-untimed-grid.js
+++ b/input/tangy-untimed-grid.js
@@ -174,6 +174,11 @@ class TangyUntimedGrid extends TangyInputBase {
         value: undefined,
         reflectToAttribute: true
       },
+      autoStopMode: {
+        type: String,
+        value: 'first', // 'first' or 'consecutive'
+        reflectToAttribute: true
+      },
       gridAutoStopped: {
         type: Boolean,
         value: undefined,
@@ -474,14 +479,29 @@ class TangyUntimedGrid extends TangyInputBase {
 
   shouldGridAutoStop() {
     const tangyToggleButtons = [].slice.call(this.shadowRoot.querySelectorAll('tangy-toggle-button'))
-    const firstXButtons = tangyToggleButtons.slice(0, this.autoStop)
-    let foundAnUnpressedButton = false
-    for (let button of firstXButtons) {
-      if (!button.pressed) {
-        foundAnUnpressedButton = true
+    if (this.autoStopMode === 'first') {
+      const firstXButtons = tangyToggleButtons.slice(0, this.autoStop)
+      let foundAnUnpressedButton = false
+      for (let button of firstXButtons) {
+        if (!button.pressed) {
+          foundAnUnpressedButton = true
+        }
       }
+      return foundAnUnpressedButton ? false : true
+    } else if (this.autoStopMode === 'consecutive') {
+      let consecutiveCount = 0
+      for (let button of tangyToggleButtons) {
+        if (button.pressed) {
+          consecutiveCount++
+          if (consecutiveCount >= this.autoStop) {
+            return true
+          }
+        } else {
+          consecutiveCount = 0
+        }
+      }
+      return false
     }
-    return foundAnUnpressedButton ? false : true
   }
 
   onStopClick(event, lastItemAttempted) {


### PR DESCRIPTION
Introduce `autoStopMode` property with 'first' and 'consecutive' modes to control auto-stop behavior in both TangyTimed and TangyUntimedGrid components.

Refs Tangerine-Community/Tangerine#3797