### PR TITLE
fix(audio): hide label initially when recording starts

### DIFF
--- a/input/tangy-audio-recording.js
+++ b/input/tangy-audio-recording.js
@@ -189,6 +189,7 @@ export class TangyAudioRecording extends TangyInputBase {
     this.shadowRoot.querySelector("#deleteRecording").style.display = "none";
     this.shadowRoot.querySelector("#recording-time").style.display = "none";
     this.shadowRoot.querySelector("#audio-motion-container").style.display = "none";
+    this.shadowRoot.querySelector("#label").style.display = "none";
   }
   reflect() {
     this.shadowRoot.querySelector("#qnum-number").innerHTML = this.hasAttribute(
@@ -298,6 +299,7 @@ export class TangyAudioRecording extends TangyInputBase {
   
   startRecording() {
     this.isRecording = true;
+    this.shadowRoot.querySelector("#label").style.display = "";
     navigator.mediaDevices
       .getUserMedia({ audio: true })
       .then((stream) => {
@@ -401,6 +403,7 @@ export class TangyAudioRecording extends TangyInputBase {
     this.shadowRoot.querySelector("#deleteRecording").style.display = "none";
     this.shadowRoot.querySelector("#recording-time").style.display = "none";
     this.shadowRoot.querySelector("#audio-motion-container").style.display = "none";
+    this.shadowRoot.querySelector("#label").style.display = "none";
   }
 }
 


### PR DESCRIPTION
Hide the label element when recording begins and show it again when recording ends to improve feedback to user.

Adds to Tangerine-Community/tangy-form/pull/429